### PR TITLE
Sign button change on certificate upload

### DIFF
--- a/CHANGES/1369.feature
+++ b/CHANGES/1369.feature
@@ -1,1 +1,1 @@
-Add signature upload elements for Insights mode
+Add signature upload elements for Insights mode. Change the Sign buttons when upload certificate enabled

--- a/CHANGES/1694.misc
+++ b/CHANGES/1694.misc
@@ -1,0 +1,1 @@
+Show sync in toggle dropdown only with user permissions to change container namespace.

--- a/CHANGES/1695.misc
+++ b/CHANGES/1695.misc
@@ -1,0 +1,1 @@
+Show sync button only with user permissions for changing a registry.

--- a/CHANGES/1696.misc
+++ b/CHANGES/1696.misc
@@ -1,0 +1,1 @@
+Only show add EE button with user model permissions.

--- a/CHANGES/1710.misc
+++ b/CHANGES/1710.misc
@@ -1,0 +1,1 @@
+Update collection signing feature flags

--- a/CHANGES/518.misc
+++ b/CHANGES/518.misc
@@ -1,0 +1,1 @@
+Add proper page load spinners to all UI pages.

--- a/CHANGES/618.test
+++ b/CHANGES/618.test
@@ -1,0 +1,1 @@
+Cypress test for editing a remote repo.

--- a/build_deploy.sh
+++ b/build_deploy.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+# --------------------------------------------
+# Export vars for helper scripts to use
+# --------------------------------------------
+# name of app-sre "application" folder this component lives in; needs to match for quay
+export COMPONENT="automation-hub"
+export WORKSPACE=${WORKSPACE:-$APP_ROOT} # if running in jenkins, use the build's workspace
+export APP_ROOT=$(pwd)
+COMMON_BUILDER=https://raw.githubusercontent.com/RedHatInsights/insights-frontend-builder-common/master
+
+export NODE_BUILD_VERSION=14
+export IMAGE="quay.io/cloudservices/ansible-hub-ui"
+
+set -exv
+# source is preferred to | bash -s in this case to avoid a subshell
+source <(curl -sSL $COMMON_BUILDER/src/frontend-build.sh)
+BUILD_RESULTS=$?
+
+# Stubbed out for now
+mkdir -p $WORKSPACE/artifacts
+cat << EOF > $WORKSPACE/artifacts/junit-dummy.xml
+<testsuite tests="1">
+    <testcase classname="dummy" name="dummytest"/>
+</testsuite>
+EOF
+
+# teardown_docker
+exit $BUILD_RESULTS

--- a/ci.sh
+++ b/ci.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+# setNpmOrYarn
+USES_NPM=true
+
+# install dependencies
+npm ci
+npm i -g npm-run-all
+
+# build
+if [ $IS_PR = true ]; then
+  #npm run verify
+  npm-run-all build:prod 'lint:!(po|yaml)'
+else
+  npm run deploy
+fi
+
+# do not use dev dockerfile
+rm $APP_ROOT/Dockerfile

--- a/deploy/frontend.yaml
+++ b/deploy/frontend.yaml
@@ -20,9 +20,21 @@ objects:
       image: ${IMAGE}:${IMAGE_TAG}
       navItems:
         - appId: "automationHub"
-          title: "Automation Hub"
+          title: "Collections"
           href: "/ansible/automation-hub"
-          product: "Red Hat Insights"
+          product: "Ansible Automation Hub"
+        - appId: "automationHub"
+          title: "Partners"
+          href: "/ansible/automation-hub/partners"
+          product: "Ansible Automation Hub"
+        - appId: "automationHub"
+          title: "Repo Management"
+          href: "/ansible/automation-hub/repositories"
+          product: "Ansible Automation Hub"
+        - appId: "automationHub"
+          title: "Connect to Hub"
+          href: "/ansible/automation-hub/token"
+          product: "Ansible Automation Hub"
       module:
         manifestLocation: "/apps/automation-hub/fed-mods.json"
         modules:

--- a/locale/en.po
+++ b/locale/en.po
@@ -194,7 +194,7 @@ msgid "Add container repository"
 msgstr "Add container repository"
 
 #: src/components/execution-environment/repository-form.tsx:152
-#: src/containers/execution-environment-list/execution_environment_list.tsx:155
+#: src/containers/execution-environment-list/execution_environment_list.tsx:157
 msgid "Add execution environment"
 msgstr "Add execution environment"
 
@@ -630,12 +630,12 @@ msgstr "Container names can only contain alphanumeric characters, \".\", \"_\", 
 msgid "Container namespace"
 msgstr "Container namespace"
 
-#: src/containers/execution-environment-list/execution_environment_list.tsx:307
+#: src/containers/execution-environment-list/execution_environment_list.tsx:310
 msgid "Container registry type"
 msgstr "Container registry type"
 
-#: src/containers/execution-environment-list/execution_environment_list.tsx:231
-#: src/containers/execution-environment-list/execution_environment_list.tsx:287
+#: src/containers/execution-environment-list/execution_environment_list.tsx:234
+#: src/containers/execution-environment-list/execution_environment_list.tsx:290
 msgid "Container repository name"
 msgstr "Container repository name"
 
@@ -718,7 +718,7 @@ msgid "Create new user"
 msgstr "Create new user"
 
 #: src/containers/execution-environment/registry-list.tsx:327
-#: src/containers/execution-environment-list/execution_environment_list.tsx:297
+#: src/containers/execution-environment-list/execution_environment_list.tsx:300
 #: src/containers/group-management/group-detail.tsx:824
 #: src/containers/user-management/user-list.tsx:286
 msgid "Created"
@@ -770,10 +770,10 @@ msgid "Date created"
 msgstr "Date created"
 
 #: src/components/delete-modal/delete-modal.tsx:29
-#: src/containers/execution-environment/registry-list.tsx:406
+#: src/containers/execution-environment/registry-list.tsx:408
 #: src/containers/execution-environment-detail/base.tsx:144
 #: src/containers/execution-environment-detail/execution_environment_detail_images.tsx:416
-#: src/containers/execution-environment-list/execution_environment_list.tsx:378
+#: src/containers/execution-environment-list/execution_environment_list.tsx:381
 #: src/containers/group-management/group-detail.tsx:272
 #: src/containers/group-management/group-list.tsx:434
 #: src/containers/task-management/task-list-view.tsx:313
@@ -955,7 +955,7 @@ msgstr "Deprecation status update starting for collection \"{0}\"."
 #: src/components/execution-environment/repository-form.tsx:368
 #: src/components/namespace-form/namespace-form.tsx:152
 #: src/components/role-list-table/role-list-table.tsx:49
-#: src/containers/execution-environment-list/execution_environment_list.tsx:292
+#: src/containers/execution-environment-list/execution_environment_list.tsx:295
 #: src/containers/task-management/task_detail.tsx:342
 msgid "Description"
 msgstr "Description"
@@ -1037,10 +1037,10 @@ msgstr "Dropdown"
 
 #: src/components/repositories/remote-repository-table.tsx:128
 #: src/containers/edit-namespace/edit-namespace.tsx:152
-#: src/containers/execution-environment/registry-list.tsx:393
+#: src/containers/execution-environment/registry-list.tsx:395
 #: src/containers/execution-environment-detail/base.tsx:194
 #: src/containers/execution-environment-detail/execution_environment_detail.tsx:99
-#: src/containers/execution-environment-list/execution_environment_list.tsx:351
+#: src/containers/execution-environment-list/execution_environment_list.tsx:354
 #: src/containers/group-management/group-detail.tsx:360
 #: src/containers/group-management/group-list.tsx:420
 #: src/containers/settings/user-profile.tsx:96
@@ -1156,7 +1156,7 @@ msgstr "Error fetching import from API"
 #~ msgid "Error loading dependent collections."
 #~ msgstr "Error loading dependent collections."
 
-#: src/containers/execution-environment-list/execution_environment_list.tsx:498
+#: src/containers/execution-environment-list/execution_environment_list.tsx:501
 msgid "Error loading environments."
 msgstr "Error loading environments."
 
@@ -1270,18 +1270,18 @@ msgid "Execution Environment"
 msgstr "Execution Environment"
 
 #: src/components/execution-environment-header/execution-environment-header.tsx:36
-#: src/containers/execution-environment-list/execution_environment_list.tsx:173
+#: src/containers/execution-environment-list/execution_environment_list.tsx:177
 #: src/containers/execution-environment-manifest/execution-environment-manifest.tsx:107
 #: src/loaders/standalone/standalone-loader.tsx:370
 #: src/loaders/standalone/standalone-loader.tsx:376
 msgid "Execution Environments"
 msgstr "Execution Environments"
 
-#: src/containers/execution-environment-list/execution_environment_list.tsx:448
+#: src/containers/execution-environment-list/execution_environment_list.tsx:451
 msgid "Execution environment \"{0}\" has been added successfully."
 msgstr "Execution environment \"{0}\" has been added successfully."
 
-#: src/containers/execution-environment/registry-list.tsx:541
+#: src/containers/execution-environment/registry-list.tsx:543
 msgid "Execution environment \"{name}\" could not be indexed."
 msgstr "Execution environment \"{name}\" could not be indexed."
 
@@ -1364,7 +1364,7 @@ msgstr "Filter by {0}"
 msgid "Find content"
 msgstr "Find content"
 
-#: src/containers/execution-environment/registry-list.tsx:413
+#: src/containers/execution-environment/registry-list.tsx:415
 msgid "Find execution environments in this registry"
 msgstr "Find execution environments in this registry"
 
@@ -1518,7 +1518,7 @@ msgstr "Import log"
 msgid "Imports"
 msgstr "Imports"
 
-#: src/containers/execution-environment/registry-list.tsx:421
+#: src/containers/execution-environment/registry-list.tsx:423
 msgid "Index execution environments"
 msgstr "Index execution environments"
 
@@ -1526,7 +1526,7 @@ msgstr "Index execution environments"
 #~ msgid "Indexing execution environments in {name}"
 #~ msgstr "Indexing execution environments in {name}"
 
-#: src/containers/execution-environment/registry-list.tsx:414
+#: src/containers/execution-environment/registry-list.tsx:416
 msgid "Indexing execution environments is only supported on registry.redhat.io"
 msgstr "Indexing execution environments is only supported on registry.redhat.io"
 
@@ -1534,7 +1534,7 @@ msgstr "Indexing execution environments is only supported on registry.redhat.io"
 #~ msgid "Indexing failed for {name}"
 #~ msgstr "Indexing failed for {name}"
 
-#: src/containers/execution-environment/registry-list.tsx:525
+#: src/containers/execution-environment/registry-list.tsx:527
 msgid "Indexing started for execution environment \"{name}\"."
 msgstr "Indexing started for execution environment \"{name}\"."
 
@@ -1591,7 +1591,7 @@ msgstr "It's safe to close this window. These tasks will finish in the backgroun
 msgid "Keywords"
 msgstr "Keywords"
 
-#: src/containers/execution-environment-list/execution_environment_list.tsx:302
+#: src/containers/execution-environment-list/execution_environment_list.tsx:305
 msgid "Last modified"
 msgstr "Last modified"
 
@@ -1656,7 +1656,7 @@ msgstr "List of Collections"
 msgid "Load token"
 msgstr "Load token"
 
-#: src/containers/execution-environment-list/execution_environment_list.tsx:408
+#: src/containers/execution-environment-list/execution_environment_list.tsx:411
 #: src/containers/repositories/repository-list.tsx:118
 msgid "Local"
 msgstr "Local"
@@ -1849,7 +1849,7 @@ msgstr "No child task"
 msgid "No collections yet"
 msgstr "No collections yet"
 
-#: src/containers/execution-environment-list/execution_environment_list.tsx:195
+#: src/containers/execution-environment-list/execution_environment_list.tsx:199
 msgid "No container repositories yet"
 msgstr "No container repositories yet"
 
@@ -2305,7 +2305,7 @@ msgstr "Reject"
 msgid "Rejected"
 msgstr "Rejected"
 
-#: src/containers/execution-environment-list/execution_environment_list.tsx:408
+#: src/containers/execution-environment-list/execution_environment_list.tsx:411
 #: src/containers/repositories/repository-list.tsx:119
 msgid "Remote"
 msgstr "Remote"
@@ -2320,15 +2320,15 @@ msgstr "Remote Registries"
 msgid "Remote name"
 msgstr "Remote name"
 
-#: src/containers/execution-environment/registry-list.tsx:480
+#: src/containers/execution-environment/registry-list.tsx:482
 msgid "Remote registry \"{name}\" could not be deleted."
 msgstr "Remote registry \"{name}\" could not be deleted."
 
-#: src/containers/execution-environment/registry-list.tsx:513
+#: src/containers/execution-environment/registry-list.tsx:515
 msgid "Remote registry \"{name}\" could not be synced."
 msgstr "Remote registry \"{name}\" could not be synced."
 
-#: src/containers/execution-environment/registry-list.tsx:471
+#: src/containers/execution-environment/registry-list.tsx:473
 msgid "Remote registry \"{name}\" has been successfully deleted."
 msgstr "Remote registry \"{name}\" has been successfully deleted."
 
@@ -2416,7 +2416,7 @@ msgid "Save"
 msgstr "Save"
 
 #: src/containers/execution-environment-detail/base.tsx:219
-#: src/containers/execution-environment-list/execution_environment_list.tsx:453
+#: src/containers/execution-environment-list/execution_environment_list.tsx:456
 msgid "Saved changes to execution environment \"{0}\"."
 msgstr "Saved changes to execution environment \"{0}\"."
 
@@ -2448,13 +2448,13 @@ msgstr "Scroll to end"
 #~ msgid "Search my namespaces"
 #~ msgstr "Search my namespaces"
 
-#: src/containers/execution-environment/registry-list.tsx:499
+#: src/containers/execution-environment/registry-list.tsx:501
 #: src/containers/execution-environment-detail/base.tsx:334
-#: src/containers/execution-environment-list/execution_environment_list.tsx:534
+#: src/containers/execution-environment-list/execution_environment_list.tsx:537
 msgid "See the task management <0>detail page </0>for the status of this task."
 msgstr "See the task management <0>detail page </0>for the status of this task."
 
-#: src/containers/execution-environment/registry-list.tsx:528
+#: src/containers/execution-environment/registry-list.tsx:530
 msgid "See the task management <0>detail page</0>for the status of this task."
 msgstr "See the task management <0>detail page</0>for the status of this task."
 
@@ -2716,13 +2716,13 @@ msgid "Sync"
 msgstr "Sync"
 
 #: src/containers/execution-environment-detail/base.tsx:345
-#: src/containers/execution-environment-list/execution_environment_list.tsx:544
+#: src/containers/execution-environment-list/execution_environment_list.tsx:547
 msgid "Sync failed for {name}"
 msgstr "Sync failed for {name}"
 
-#: src/containers/execution-environment/registry-list.tsx:375
+#: src/containers/execution-environment/registry-list.tsx:376
 #: src/containers/execution-environment-detail/base.tsx:122
-#: src/containers/execution-environment-list/execution_environment_list.tsx:356
+#: src/containers/execution-environment-list/execution_environment_list.tsx:359
 msgid "Sync from registry"
 msgstr "Sync from registry"
 
@@ -2732,11 +2732,11 @@ msgstr "Sync from registry"
 #~ msgid "Sync initiated for {name}"
 #~ msgstr "Sync initiated for {name}"
 
-#: src/containers/execution-environment-list/execution_environment_list.tsx:529
+#: src/containers/execution-environment-list/execution_environment_list.tsx:532
 msgid "Sync started for execution environment \"{name}\"."
 msgstr "Sync started for execution environment \"{name}\"."
 
-#: src/containers/execution-environment/registry-list.tsx:496
+#: src/containers/execution-environment/registry-list.tsx:498
 #: src/containers/execution-environment-detail/base.tsx:331
 msgid "Sync started for remote registry \"{name}\"."
 msgstr "Sync started for remote registry \"{name}\"."
@@ -3048,7 +3048,7 @@ msgstr "Upstream name"
 #: src/components/execution-environment/publish-to-controller-modal.tsx:279
 #: src/containers/execution-environment-detail/base.tsx:135
 #: src/containers/execution-environment-detail/execution_environment_detail_images.tsx:408
-#: src/containers/execution-environment-list/execution_environment_list.tsx:369
+#: src/containers/execution-environment-list/execution_environment_list.tsx:372
 msgid "Use in Controller"
 msgstr "Use in Controller"
 
@@ -3314,7 +3314,7 @@ msgstr "You are an SSO user. Your token will expire <0/>."
 msgid "You can can customize the Resources tab on your profile by entering custom markdown here."
 msgstr "You can can customize the Resources tab on your profile by entering custom markdown here."
 
-#: src/containers/execution-environment-list/execution_environment_list.tsx:196
+#: src/containers/execution-environment-list/execution_environment_list.tsx:200
 msgid "You currently have no container repositories. Add a container repository via the CLI to get started."
 msgstr "You currently have no container repositories. Add a container repository via the CLI to get started."
 

--- a/locale/es.po
+++ b/locale/es.po
@@ -193,7 +193,7 @@ msgid "Add container repository"
 msgstr "Agregar el repositorio de contenedores"
 
 #: src/components/execution-environment/repository-form.tsx:152
-#: src/containers/execution-environment-list/execution_environment_list.tsx:155
+#: src/containers/execution-environment-list/execution_environment_list.tsx:157
 msgid "Add execution environment"
 msgstr "Agregar entorno de ejecución"
 
@@ -629,12 +629,12 @@ msgstr "Los nombres de los contenedores solo pueden contener caracteres alfanum�
 msgid "Container namespace"
 msgstr "Espacio de nombres del contenedor"
 
-#: src/containers/execution-environment-list/execution_environment_list.tsx:307
+#: src/containers/execution-environment-list/execution_environment_list.tsx:310
 msgid "Container registry type"
 msgstr "Tipo de registro de contenedores"
 
-#: src/containers/execution-environment-list/execution_environment_list.tsx:231
-#: src/containers/execution-environment-list/execution_environment_list.tsx:287
+#: src/containers/execution-environment-list/execution_environment_list.tsx:234
+#: src/containers/execution-environment-list/execution_environment_list.tsx:290
 msgid "Container repository name"
 msgstr "Nombre del repositorio de contenedores"
 
@@ -717,7 +717,7 @@ msgid "Create new user"
 msgstr "Crear nuevo usuario"
 
 #: src/containers/execution-environment/registry-list.tsx:327
-#: src/containers/execution-environment-list/execution_environment_list.tsx:297
+#: src/containers/execution-environment-list/execution_environment_list.tsx:300
 #: src/containers/group-management/group-detail.tsx:824
 #: src/containers/user-management/user-list.tsx:286
 msgid "Created"
@@ -769,10 +769,10 @@ msgid "Date created"
 msgstr "Fecha de creación"
 
 #: src/components/delete-modal/delete-modal.tsx:29
-#: src/containers/execution-environment/registry-list.tsx:406
+#: src/containers/execution-environment/registry-list.tsx:408
 #: src/containers/execution-environment-detail/base.tsx:144
 #: src/containers/execution-environment-detail/execution_environment_detail_images.tsx:416
-#: src/containers/execution-environment-list/execution_environment_list.tsx:378
+#: src/containers/execution-environment-list/execution_environment_list.tsx:381
 #: src/containers/group-management/group-detail.tsx:272
 #: src/containers/group-management/group-list.tsx:434
 #: src/containers/task-management/task-list-view.tsx:313
@@ -954,7 +954,7 @@ msgstr ""
 #: src/components/execution-environment/repository-form.tsx:368
 #: src/components/namespace-form/namespace-form.tsx:152
 #: src/components/role-list-table/role-list-table.tsx:49
-#: src/containers/execution-environment-list/execution_environment_list.tsx:292
+#: src/containers/execution-environment-list/execution_environment_list.tsx:295
 #: src/containers/task-management/task_detail.tsx:342
 msgid "Description"
 msgstr "Descripción"
@@ -1036,10 +1036,10 @@ msgstr "Desplegable"
 
 #: src/components/repositories/remote-repository-table.tsx:128
 #: src/containers/edit-namespace/edit-namespace.tsx:152
-#: src/containers/execution-environment/registry-list.tsx:393
+#: src/containers/execution-environment/registry-list.tsx:395
 #: src/containers/execution-environment-detail/base.tsx:194
 #: src/containers/execution-environment-detail/execution_environment_detail.tsx:99
-#: src/containers/execution-environment-list/execution_environment_list.tsx:351
+#: src/containers/execution-environment-list/execution_environment_list.tsx:354
 #: src/containers/group-management/group-detail.tsx:360
 #: src/containers/group-management/group-list.tsx:420
 #: src/containers/settings/user-profile.tsx:96
@@ -1155,7 +1155,7 @@ msgstr "Error al importar desde la API"
 #~ msgid "Error loading dependent collections."
 #~ msgstr "Error loading dependent collections."
 
-#: src/containers/execution-environment-list/execution_environment_list.tsx:498
+#: src/containers/execution-environment-list/execution_environment_list.tsx:501
 msgid "Error loading environments."
 msgstr "Error al cargar los entornos."
 
@@ -1269,18 +1269,18 @@ msgid "Execution Environment"
 msgstr "Entorno de ejecución"
 
 #: src/components/execution-environment-header/execution-environment-header.tsx:36
-#: src/containers/execution-environment-list/execution_environment_list.tsx:173
+#: src/containers/execution-environment-list/execution_environment_list.tsx:177
 #: src/containers/execution-environment-manifest/execution-environment-manifest.tsx:107
 #: src/loaders/standalone/standalone-loader.tsx:370
 #: src/loaders/standalone/standalone-loader.tsx:376
 msgid "Execution Environments"
 msgstr "Entornos de ejecución"
 
-#: src/containers/execution-environment-list/execution_environment_list.tsx:448
+#: src/containers/execution-environment-list/execution_environment_list.tsx:451
 msgid "Execution environment \"{0}\" has been added successfully."
 msgstr ""
 
-#: src/containers/execution-environment/registry-list.tsx:541
+#: src/containers/execution-environment/registry-list.tsx:543
 msgid "Execution environment \"{name}\" could not be indexed."
 msgstr "No se pudo indexar el entorno de ejecución \"{name}\"."
 
@@ -1363,7 +1363,7 @@ msgstr "Filtrar por {0}"
 msgid "Find content"
 msgstr "Buscar contenido"
 
-#: src/containers/execution-environment/registry-list.tsx:413
+#: src/containers/execution-environment/registry-list.tsx:415
 msgid "Find execution environments in this registry"
 msgstr "Buscar entornos de ejecución en este registro"
 
@@ -1517,7 +1517,7 @@ msgstr "Registro de importación"
 msgid "Imports"
 msgstr "Importaciones"
 
-#: src/containers/execution-environment/registry-list.tsx:421
+#: src/containers/execution-environment/registry-list.tsx:423
 msgid "Index execution environments"
 msgstr "Entornos de ejecución de índices"
 
@@ -1525,7 +1525,7 @@ msgstr "Entornos de ejecución de índices"
 #~ msgid "Indexing execution environments in {name}"
 #~ msgstr "Indexing execution environments in {name}"
 
-#: src/containers/execution-environment/registry-list.tsx:414
+#: src/containers/execution-environment/registry-list.tsx:416
 msgid "Indexing execution environments is only supported on registry.redhat.io"
 msgstr "La indexación de entornos de ejecución sólo es compatible con registry.redhat.io"
 
@@ -1533,7 +1533,7 @@ msgstr "La indexación de entornos de ejecución sólo es compatible con registr
 #~ msgid "Indexing failed for {name}"
 #~ msgstr "Indexing failed for {name}"
 
-#: src/containers/execution-environment/registry-list.tsx:525
+#: src/containers/execution-environment/registry-list.tsx:527
 msgid "Indexing started for execution environment \"{name}\"."
 msgstr "Se inició la indexación para el entorno de ejecución \"{name}\"."
 
@@ -1590,7 +1590,7 @@ msgstr "Es seguro cerrar esta ventana. Estas tareas terminarán en segundo plano
 msgid "Keywords"
 msgstr "Palabras clave"
 
-#: src/containers/execution-environment-list/execution_environment_list.tsx:302
+#: src/containers/execution-environment-list/execution_environment_list.tsx:305
 msgid "Last modified"
 msgstr "Última modificación"
 
@@ -1655,7 +1655,7 @@ msgstr "Lista de colecciones"
 msgid "Load token"
 msgstr "Ficha de carga"
 
-#: src/containers/execution-environment-list/execution_environment_list.tsx:408
+#: src/containers/execution-environment-list/execution_environment_list.tsx:411
 #: src/containers/repositories/repository-list.tsx:118
 msgid "Local"
 msgstr "Local"
@@ -1848,7 +1848,7 @@ msgstr "Ninguna tarea infantil"
 msgid "No collections yet"
 msgstr "Todavía no hay colecciones"
 
-#: src/containers/execution-environment-list/execution_environment_list.tsx:195
+#: src/containers/execution-environment-list/execution_environment_list.tsx:199
 msgid "No container repositories yet"
 msgstr "Todavía no hay repositorios de contenedores"
 
@@ -2304,7 +2304,7 @@ msgstr "Rechazar"
 msgid "Rejected"
 msgstr "Rechazado"
 
-#: src/containers/execution-environment-list/execution_environment_list.tsx:408
+#: src/containers/execution-environment-list/execution_environment_list.tsx:411
 #: src/containers/repositories/repository-list.tsx:119
 msgid "Remote"
 msgstr "Remoto"
@@ -2319,15 +2319,15 @@ msgstr "Registros remotos"
 msgid "Remote name"
 msgstr "Nombre remoto"
 
-#: src/containers/execution-environment/registry-list.tsx:480
+#: src/containers/execution-environment/registry-list.tsx:482
 msgid "Remote registry \"{name}\" could not be deleted."
 msgstr "No se pudo eliminar el registro remoto \"{name}\"."
 
-#: src/containers/execution-environment/registry-list.tsx:513
+#: src/containers/execution-environment/registry-list.tsx:515
 msgid "Remote registry \"{name}\" could not be synced."
 msgstr "No se pudo sincronizar el registro remoto \"{name}\"."
 
-#: src/containers/execution-environment/registry-list.tsx:471
+#: src/containers/execution-environment/registry-list.tsx:473
 msgid "Remote registry \"{name}\" has been successfully deleted."
 msgstr "El registro remoto \"{name}\" se eliminó correctamente."
 
@@ -2415,7 +2415,7 @@ msgid "Save"
 msgstr "Guardar"
 
 #: src/containers/execution-environment-detail/base.tsx:219
-#: src/containers/execution-environment-list/execution_environment_list.tsx:453
+#: src/containers/execution-environment-list/execution_environment_list.tsx:456
 msgid "Saved changes to execution environment \"{0}\"."
 msgstr "Se guardaron los cambios en el entorno de ejecución \"{0}\"."
 
@@ -2447,13 +2447,13 @@ msgstr "Desplácese hasta el final"
 #~ msgid "Search my namespaces"
 #~ msgstr "Search my namespaces"
 
-#: src/containers/execution-environment/registry-list.tsx:499
+#: src/containers/execution-environment/registry-list.tsx:501
 #: src/containers/execution-environment-detail/base.tsx:334
-#: src/containers/execution-environment-list/execution_environment_list.tsx:534
+#: src/containers/execution-environment-list/execution_environment_list.tsx:537
 msgid "See the task management <0>detail page </0>for the status of this task."
 msgstr "Consulte la página de detalle <0>de gestión de tareas </0>para ver el estado de esta tarea."
 
-#: src/containers/execution-environment/registry-list.tsx:528
+#: src/containers/execution-environment/registry-list.tsx:530
 msgid "See the task management <0>detail page</0>for the status of this task."
 msgstr "Consulte la página de detalle <0>de gestión de tareas</0>para ver el estado de esta tarea."
 
@@ -2715,13 +2715,13 @@ msgid "Sync"
 msgstr "Sincronizar"
 
 #: src/containers/execution-environment-detail/base.tsx:345
-#: src/containers/execution-environment-list/execution_environment_list.tsx:544
+#: src/containers/execution-environment-list/execution_environment_list.tsx:547
 msgid "Sync failed for {name}"
 msgstr "Sincronización fallida para {name}"
 
-#: src/containers/execution-environment/registry-list.tsx:375
+#: src/containers/execution-environment/registry-list.tsx:376
 #: src/containers/execution-environment-detail/base.tsx:122
-#: src/containers/execution-environment-list/execution_environment_list.tsx:356
+#: src/containers/execution-environment-list/execution_environment_list.tsx:359
 msgid "Sync from registry"
 msgstr "Sincronización desde el registro"
 
@@ -2731,11 +2731,11 @@ msgstr "Sincronización desde el registro"
 #~ msgid "Sync initiated for {name}"
 #~ msgstr "Sync initiated for {name}"
 
-#: src/containers/execution-environment-list/execution_environment_list.tsx:529
+#: src/containers/execution-environment-list/execution_environment_list.tsx:532
 msgid "Sync started for execution environment \"{name}\"."
 msgstr "Se inició la sincronización para el entorno de ejecución \"{name}\"."
 
-#: src/containers/execution-environment/registry-list.tsx:496
+#: src/containers/execution-environment/registry-list.tsx:498
 #: src/containers/execution-environment-detail/base.tsx:331
 msgid "Sync started for remote registry \"{name}\"."
 msgstr "Se inició la sincronización para el registro remoto \"{name}\"."
@@ -3047,7 +3047,7 @@ msgstr "Nombre del upstream"
 #: src/components/execution-environment/publish-to-controller-modal.tsx:279
 #: src/containers/execution-environment-detail/base.tsx:135
 #: src/containers/execution-environment-detail/execution_environment_detail_images.tsx:408
-#: src/containers/execution-environment-list/execution_environment_list.tsx:369
+#: src/containers/execution-environment-list/execution_environment_list.tsx:372
 msgid "Use in Controller"
 msgstr "Uso en el controlador"
 
@@ -3313,7 +3313,7 @@ msgstr "Usted es un usuario SSO. Su token expirará <0/>."
 msgid "You can can customize the Resources tab on your profile by entering custom markdown here."
 msgstr "Puede personalizar la pestaña de Recursos de su perfil introduciendo aquí una marca personalizada."
 
-#: src/containers/execution-environment-list/execution_environment_list.tsx:196
+#: src/containers/execution-environment-list/execution_environment_list.tsx:200
 msgid "You currently have no container repositories. Add a container repository via the CLI to get started."
 msgstr "Actualmente no tiene repositorios de contenedores. Añada un repositorio de contenedores a través de la CLI para empezar."
 

--- a/locale/fr.po
+++ b/locale/fr.po
@@ -193,7 +193,7 @@ msgid "Add container repository"
 msgstr "Ajouter le référentiel du conteneur"
 
 #: src/components/execution-environment/repository-form.tsx:152
-#: src/containers/execution-environment-list/execution_environment_list.tsx:155
+#: src/containers/execution-environment-list/execution_environment_list.tsx:157
 msgid "Add execution environment"
 msgstr "Ajoutez un environnement d'exécution"
 
@@ -627,12 +627,12 @@ msgstr "Les noms de conteneurs ne peuvent contenir que des chiffres alphanuméri
 msgid "Container namespace"
 msgstr "Espace de noms des conteneurs"
 
-#: src/containers/execution-environment-list/execution_environment_list.tsx:307
+#: src/containers/execution-environment-list/execution_environment_list.tsx:310
 msgid "Container registry type"
 msgstr "Type de registre des conteneurs"
 
-#: src/containers/execution-environment-list/execution_environment_list.tsx:231
-#: src/containers/execution-environment-list/execution_environment_list.tsx:287
+#: src/containers/execution-environment-list/execution_environment_list.tsx:234
+#: src/containers/execution-environment-list/execution_environment_list.tsx:290
 msgid "Container repository name"
 msgstr "Nom du référentiel du conteneur"
 
@@ -715,7 +715,7 @@ msgid "Create new user"
 msgstr "Créer un nouvel utilisateur"
 
 #: src/containers/execution-environment/registry-list.tsx:327
-#: src/containers/execution-environment-list/execution_environment_list.tsx:297
+#: src/containers/execution-environment-list/execution_environment_list.tsx:300
 #: src/containers/group-management/group-detail.tsx:824
 #: src/containers/user-management/user-list.tsx:286
 msgid "Created"
@@ -767,10 +767,10 @@ msgid "Date created"
 msgstr "Date de création"
 
 #: src/components/delete-modal/delete-modal.tsx:29
-#: src/containers/execution-environment/registry-list.tsx:406
+#: src/containers/execution-environment/registry-list.tsx:408
 #: src/containers/execution-environment-detail/base.tsx:144
 #: src/containers/execution-environment-detail/execution_environment_detail_images.tsx:416
-#: src/containers/execution-environment-list/execution_environment_list.tsx:378
+#: src/containers/execution-environment-list/execution_environment_list.tsx:381
 #: src/containers/group-management/group-detail.tsx:272
 #: src/containers/group-management/group-list.tsx:434
 #: src/containers/task-management/task-list-view.tsx:313
@@ -952,7 +952,7 @@ msgstr ""
 #: src/components/execution-environment/repository-form.tsx:368
 #: src/components/namespace-form/namespace-form.tsx:152
 #: src/components/role-list-table/role-list-table.tsx:49
-#: src/containers/execution-environment-list/execution_environment_list.tsx:292
+#: src/containers/execution-environment-list/execution_environment_list.tsx:295
 #: src/containers/task-management/task_detail.tsx:342
 msgid "Description"
 msgstr "Description"
@@ -1034,10 +1034,10 @@ msgstr "Menu déroulant"
 
 #: src/components/repositories/remote-repository-table.tsx:128
 #: src/containers/edit-namespace/edit-namespace.tsx:152
-#: src/containers/execution-environment/registry-list.tsx:393
+#: src/containers/execution-environment/registry-list.tsx:395
 #: src/containers/execution-environment-detail/base.tsx:194
 #: src/containers/execution-environment-detail/execution_environment_detail.tsx:99
-#: src/containers/execution-environment-list/execution_environment_list.tsx:351
+#: src/containers/execution-environment-list/execution_environment_list.tsx:354
 #: src/containers/group-management/group-detail.tsx:360
 #: src/containers/group-management/group-list.tsx:420
 #: src/containers/settings/user-profile.tsx:96
@@ -1153,7 +1153,7 @@ msgstr "Erreur lors de la récupération de l'importation à partir de l'API"
 #~ msgid "Error loading dependent collections."
 #~ msgstr "Error loading dependent collections."
 
-#: src/containers/execution-environment-list/execution_environment_list.tsx:498
+#: src/containers/execution-environment-list/execution_environment_list.tsx:501
 msgid "Error loading environments."
 msgstr "Erreur de chargement des environnements."
 
@@ -1267,18 +1267,18 @@ msgid "Execution Environment"
 msgstr "Environnement d'exécution"
 
 #: src/components/execution-environment-header/execution-environment-header.tsx:36
-#: src/containers/execution-environment-list/execution_environment_list.tsx:173
+#: src/containers/execution-environment-list/execution_environment_list.tsx:177
 #: src/containers/execution-environment-manifest/execution-environment-manifest.tsx:107
 #: src/loaders/standalone/standalone-loader.tsx:370
 #: src/loaders/standalone/standalone-loader.tsx:376
 msgid "Execution Environments"
 msgstr "Environnements d'exécution"
 
-#: src/containers/execution-environment-list/execution_environment_list.tsx:448
+#: src/containers/execution-environment-list/execution_environment_list.tsx:451
 msgid "Execution environment \"{0}\" has been added successfully."
 msgstr ""
 
-#: src/containers/execution-environment/registry-list.tsx:541
+#: src/containers/execution-environment/registry-list.tsx:543
 msgid "Execution environment \"{name}\" could not be indexed."
 msgstr "Environnements d'exécution \"{name}\" n’a pas pu être indexé."
 
@@ -1361,7 +1361,7 @@ msgstr "Filtrer par {0}"
 msgid "Find content"
 msgstr "Trouver contenu"
 
-#: src/containers/execution-environment/registry-list.tsx:413
+#: src/containers/execution-environment/registry-list.tsx:415
 msgid "Find execution environments in this registry"
 msgstr "Trouver les environnements d'exécution dans ce registre"
 
@@ -1515,7 +1515,7 @@ msgstr "Journal des importations"
 msgid "Imports"
 msgstr "Importations"
 
-#: src/containers/execution-environment/registry-list.tsx:421
+#: src/containers/execution-environment/registry-list.tsx:423
 msgid "Index execution environments"
 msgstr "Indexation des environnements d'exécution"
 
@@ -1523,7 +1523,7 @@ msgstr "Indexation des environnements d'exécution"
 #~ msgid "Indexing execution environments in {name}"
 #~ msgstr "Indexing execution environments in {name}"
 
-#: src/containers/execution-environment/registry-list.tsx:414
+#: src/containers/execution-environment/registry-list.tsx:416
 msgid "Indexing execution environments is only supported on registry.redhat.io"
 msgstr "L'indexation des environnements d'exécution n'est prise en charge que sur registry.redhat.io"
 
@@ -1531,7 +1531,7 @@ msgstr "L'indexation des environnements d'exécution n'est prise en charge que s
 #~ msgid "Indexing failed for {name}"
 #~ msgstr "Indexing failed for {name}"
 
-#: src/containers/execution-environment/registry-list.tsx:525
+#: src/containers/execution-environment/registry-list.tsx:527
 msgid "Indexing started for execution environment \"{name}\"."
 msgstr "L’indexation commence pour l’environnement d’exécution \"{name}\"."
 
@@ -1588,7 +1588,7 @@ msgstr "Vous pouvez fermer cette fenêtre en toute sécurité. Ces tâches se te
 msgid "Keywords"
 msgstr "Mots clés"
 
-#: src/containers/execution-environment-list/execution_environment_list.tsx:302
+#: src/containers/execution-environment-list/execution_environment_list.tsx:305
 msgid "Last modified"
 msgstr "Dernière modification"
 
@@ -1653,7 +1653,7 @@ msgstr "Liste des collections"
 msgid "Load token"
 msgstr "Jeton de charge"
 
-#: src/containers/execution-environment-list/execution_environment_list.tsx:408
+#: src/containers/execution-environment-list/execution_environment_list.tsx:411
 #: src/containers/repositories/repository-list.tsx:118
 msgid "Local"
 msgstr "Local"
@@ -1846,7 +1846,7 @@ msgstr "Aucune tâche dépendante"
 msgid "No collections yet"
 msgstr "Pas encore de collections"
 
-#: src/containers/execution-environment-list/execution_environment_list.tsx:195
+#: src/containers/execution-environment-list/execution_environment_list.tsx:199
 msgid "No container repositories yet"
 msgstr "Pas encore de référentiels de conteneurs"
 
@@ -2302,7 +2302,7 @@ msgstr "Rejeter"
 msgid "Rejected"
 msgstr "Rejeté"
 
-#: src/containers/execution-environment-list/execution_environment_list.tsx:408
+#: src/containers/execution-environment-list/execution_environment_list.tsx:411
 #: src/containers/repositories/repository-list.tsx:119
 msgid "Remote"
 msgstr "Utilisateur à distance"
@@ -2317,15 +2317,15 @@ msgstr "Registres distants"
 msgid "Remote name"
 msgstr "Nom de l’utilisateur à distance"
 
-#: src/containers/execution-environment/registry-list.tsx:480
+#: src/containers/execution-environment/registry-list.tsx:482
 msgid "Remote registry \"{name}\" could not be deleted."
 msgstr "Le registre distant \"{name}\" n’a pas pu être supprimé."
 
-#: src/containers/execution-environment/registry-list.tsx:513
+#: src/containers/execution-environment/registry-list.tsx:515
 msgid "Remote registry \"{name}\" could not be synced."
 msgstr "Le registre distant \"{name}\" n’a pas pu être synchronisé."
 
-#: src/containers/execution-environment/registry-list.tsx:471
+#: src/containers/execution-environment/registry-list.tsx:473
 msgid "Remote registry \"{name}\" has been successfully deleted."
 msgstr "Suppression réussie du registre distant  \"{name}\" ."
 
@@ -2413,7 +2413,7 @@ msgid "Save"
 msgstr "Enregistrer"
 
 #: src/containers/execution-environment-detail/base.tsx:219
-#: src/containers/execution-environment-list/execution_environment_list.tsx:453
+#: src/containers/execution-environment-list/execution_environment_list.tsx:456
 msgid "Saved changes to execution environment \"{0}\"."
 msgstr "Changements à l’environnement d'exécution \"{0}\" sauvegardé."
 
@@ -2445,13 +2445,13 @@ msgstr "Faites défiler jusqu'à la fin"
 #~ msgid "Search my namespaces"
 #~ msgstr "Search my namespaces"
 
-#: src/containers/execution-environment/registry-list.tsx:499
+#: src/containers/execution-environment/registry-list.tsx:501
 #: src/containers/execution-environment-detail/base.tsx:334
-#: src/containers/execution-environment-list/execution_environment_list.tsx:534
+#: src/containers/execution-environment-list/execution_environment_list.tsx:537
 msgid "See the task management <0>detail page </0>for the status of this task."
 msgstr "Voir la <0>page de détails </0> de gestion des tâches pour voir le statut de cette tâche."
 
-#: src/containers/execution-environment/registry-list.tsx:528
+#: src/containers/execution-environment/registry-list.tsx:530
 msgid "See the task management <0>detail page</0>for the status of this task."
 msgstr "Voir la <0>page de détails </0> de gestion des tâches pour voir le statut de cette tâche.."
 
@@ -2713,13 +2713,13 @@ msgid "Sync"
 msgstr "Sync"
 
 #: src/containers/execution-environment-detail/base.tsx:345
-#: src/containers/execution-environment-list/execution_environment_list.tsx:544
+#: src/containers/execution-environment-list/execution_environment_list.tsx:547
 msgid "Sync failed for {name}"
 msgstr "Sync a échoué pour {name}"
 
-#: src/containers/execution-environment/registry-list.tsx:375
+#: src/containers/execution-environment/registry-list.tsx:376
 #: src/containers/execution-environment-detail/base.tsx:122
-#: src/containers/execution-environment-list/execution_environment_list.tsx:356
+#: src/containers/execution-environment-list/execution_environment_list.tsx:359
 msgid "Sync from registry"
 msgstr "Sync à partir du registre"
 
@@ -2729,11 +2729,11 @@ msgstr "Sync à partir du registre"
 #~ msgid "Sync initiated for {name}"
 #~ msgstr "Sync initiated for {name}"
 
-#: src/containers/execution-environment-list/execution_environment_list.tsx:529
+#: src/containers/execution-environment-list/execution_environment_list.tsx:532
 msgid "Sync started for execution environment \"{name}\"."
 msgstr "Sync démarrée pour l’environnement d’exécution \"{name}\"."
 
-#: src/containers/execution-environment/registry-list.tsx:496
+#: src/containers/execution-environment/registry-list.tsx:498
 #: src/containers/execution-environment-detail/base.tsx:331
 msgid "Sync started for remote registry \"{name}\"."
 msgstr "Sync démarrée pour le registre distant \"{name}\"."
@@ -3045,7 +3045,7 @@ msgstr "Nom en amont"
 #: src/components/execution-environment/publish-to-controller-modal.tsx:279
 #: src/containers/execution-environment-detail/base.tsx:135
 #: src/containers/execution-environment-detail/execution_environment_detail_images.tsx:408
-#: src/containers/execution-environment-list/execution_environment_list.tsx:369
+#: src/containers/execution-environment-list/execution_environment_list.tsx:372
 msgid "Use in Controller"
 msgstr "Utilisation dans le contrôleur"
 
@@ -3311,7 +3311,7 @@ msgstr "Vous êtes un utilisateur SSO. Votre jeton va expirer <0/>."
 msgid "You can can customize the Resources tab on your profile by entering custom markdown here."
 msgstr "Vous pouvez personnaliser l'onglet \"Ressources\" de votre profil en saisissant des tag personnalisées ici."
 
-#: src/containers/execution-environment-list/execution_environment_list.tsx:196
+#: src/containers/execution-environment-list/execution_environment_list.tsx:200
 msgid "You currently have no container repositories. Add a container repository via the CLI to get started."
 msgstr "Vous n'avez actuellement aucun référentiel de conteneur. Ajoutez un référentiel de conteneurs via le CLI pour commencer."
 

--- a/locale/ja.po
+++ b/locale/ja.po
@@ -193,7 +193,7 @@ msgid "Add container repository"
 msgstr "コンテナーリポジトリーの追加"
 
 #: src/components/execution-environment/repository-form.tsx:152
-#: src/containers/execution-environment-list/execution_environment_list.tsx:155
+#: src/containers/execution-environment-list/execution_environment_list.tsx:157
 msgid "Add execution environment"
 msgstr "実行環境の追加"
 
@@ -627,12 +627,12 @@ msgstr "コンテナー名には、英数字、「.」、「_」、「-」、お
 msgid "Container namespace"
 msgstr "コンテナーの名前空間"
 
-#: src/containers/execution-environment-list/execution_environment_list.tsx:307
+#: src/containers/execution-environment-list/execution_environment_list.tsx:310
 msgid "Container registry type"
 msgstr "コンテナーレジストリータイプ"
 
-#: src/containers/execution-environment-list/execution_environment_list.tsx:231
-#: src/containers/execution-environment-list/execution_environment_list.tsx:287
+#: src/containers/execution-environment-list/execution_environment_list.tsx:234
+#: src/containers/execution-environment-list/execution_environment_list.tsx:290
 msgid "Container repository name"
 msgstr "コンテナーリポジトリー名"
 
@@ -715,7 +715,7 @@ msgid "Create new user"
 msgstr "新規ユーザーの作成"
 
 #: src/containers/execution-environment/registry-list.tsx:327
-#: src/containers/execution-environment-list/execution_environment_list.tsx:297
+#: src/containers/execution-environment-list/execution_environment_list.tsx:300
 #: src/containers/group-management/group-detail.tsx:824
 #: src/containers/user-management/user-list.tsx:286
 msgid "Created"
@@ -767,10 +767,10 @@ msgid "Date created"
 msgstr "作成日"
 
 #: src/components/delete-modal/delete-modal.tsx:29
-#: src/containers/execution-environment/registry-list.tsx:406
+#: src/containers/execution-environment/registry-list.tsx:408
 #: src/containers/execution-environment-detail/base.tsx:144
 #: src/containers/execution-environment-detail/execution_environment_detail_images.tsx:416
-#: src/containers/execution-environment-list/execution_environment_list.tsx:378
+#: src/containers/execution-environment-list/execution_environment_list.tsx:381
 #: src/containers/group-management/group-detail.tsx:272
 #: src/containers/group-management/group-list.tsx:434
 #: src/containers/task-management/task-list-view.tsx:313
@@ -952,7 +952,7 @@ msgstr ""
 #: src/components/execution-environment/repository-form.tsx:368
 #: src/components/namespace-form/namespace-form.tsx:152
 #: src/components/role-list-table/role-list-table.tsx:49
-#: src/containers/execution-environment-list/execution_environment_list.tsx:292
+#: src/containers/execution-environment-list/execution_environment_list.tsx:295
 #: src/containers/task-management/task_detail.tsx:342
 msgid "Description"
 msgstr "説明"
@@ -1034,10 +1034,10 @@ msgstr "ドロップダウン"
 
 #: src/components/repositories/remote-repository-table.tsx:128
 #: src/containers/edit-namespace/edit-namespace.tsx:152
-#: src/containers/execution-environment/registry-list.tsx:393
+#: src/containers/execution-environment/registry-list.tsx:395
 #: src/containers/execution-environment-detail/base.tsx:194
 #: src/containers/execution-environment-detail/execution_environment_detail.tsx:99
-#: src/containers/execution-environment-list/execution_environment_list.tsx:351
+#: src/containers/execution-environment-list/execution_environment_list.tsx:354
 #: src/containers/group-management/group-detail.tsx:360
 #: src/containers/group-management/group-list.tsx:420
 #: src/containers/settings/user-profile.tsx:96
@@ -1153,7 +1153,7 @@ msgstr "API からのインポート取得エラー"
 #~ msgid "Error loading dependent collections."
 #~ msgstr "Error loading dependent collections."
 
-#: src/containers/execution-environment-list/execution_environment_list.tsx:498
+#: src/containers/execution-environment-list/execution_environment_list.tsx:501
 msgid "Error loading environments."
 msgstr "環境の読み込みエラー。"
 
@@ -1267,18 +1267,18 @@ msgid "Execution Environment"
 msgstr "実行環境"
 
 #: src/components/execution-environment-header/execution-environment-header.tsx:36
-#: src/containers/execution-environment-list/execution_environment_list.tsx:173
+#: src/containers/execution-environment-list/execution_environment_list.tsx:177
 #: src/containers/execution-environment-manifest/execution-environment-manifest.tsx:107
 #: src/loaders/standalone/standalone-loader.tsx:370
 #: src/loaders/standalone/standalone-loader.tsx:376
 msgid "Execution Environments"
 msgstr "実行環境"
 
-#: src/containers/execution-environment-list/execution_environment_list.tsx:448
+#: src/containers/execution-environment-list/execution_environment_list.tsx:451
 msgid "Execution environment \"{0}\" has been added successfully."
 msgstr ""
 
-#: src/containers/execution-environment/registry-list.tsx:541
+#: src/containers/execution-environment/registry-list.tsx:543
 msgid "Execution environment \"{name}\" could not be indexed."
 msgstr "実行環境 \"{name}\" をインデックス化できませんでした。"
 
@@ -1361,7 +1361,7 @@ msgstr "{0} 別にフィルター"
 msgid "Find content"
 msgstr "コンテンツの検索"
 
-#: src/containers/execution-environment/registry-list.tsx:413
+#: src/containers/execution-environment/registry-list.tsx:415
 msgid "Find execution environments in this registry"
 msgstr "このレジストリーでの実行環境の検索"
 
@@ -1515,7 +1515,7 @@ msgstr "ログのインポート"
 msgid "Imports"
 msgstr "インポート"
 
-#: src/containers/execution-environment/registry-list.tsx:421
+#: src/containers/execution-environment/registry-list.tsx:423
 msgid "Index execution environments"
 msgstr "実行環境のインデックス作成"
 
@@ -1523,7 +1523,7 @@ msgstr "実行環境のインデックス作成"
 #~ msgid "Indexing execution environments in {name}"
 #~ msgstr "Indexing execution environments in {name}"
 
-#: src/containers/execution-environment/registry-list.tsx:414
+#: src/containers/execution-environment/registry-list.tsx:416
 msgid "Indexing execution environments is only supported on registry.redhat.io"
 msgstr "実行環境は registry.redhat.io でのみサポートされます。"
 
@@ -1531,7 +1531,7 @@ msgstr "実行環境は registry.redhat.io でのみサポートされます。"
 #~ msgid "Indexing failed for {name}"
 #~ msgstr "Indexing failed for {name}"
 
-#: src/containers/execution-environment/registry-list.tsx:525
+#: src/containers/execution-environment/registry-list.tsx:527
 msgid "Indexing started for execution environment \"{name}\"."
 msgstr "実行環境 \"{name}\" のインデックス化が開始されました。"
 
@@ -1588,7 +1588,7 @@ msgstr "このウィンドウを安全に閉じることができます。この
 msgid "Keywords"
 msgstr "キーワード"
 
-#: src/containers/execution-environment-list/execution_environment_list.tsx:302
+#: src/containers/execution-environment-list/execution_environment_list.tsx:305
 msgid "Last modified"
 msgstr "最終更新日"
 
@@ -1653,7 +1653,7 @@ msgstr "コレクションの一覧"
 msgid "Load token"
 msgstr "トークンの読み込み"
 
-#: src/containers/execution-environment-list/execution_environment_list.tsx:408
+#: src/containers/execution-environment-list/execution_environment_list.tsx:411
 #: src/containers/repositories/repository-list.tsx:118
 msgid "Local"
 msgstr "ローカル"
@@ -1846,7 +1846,7 @@ msgstr "子タスクなし"
 msgid "No collections yet"
 msgstr "まだコレクションはありません"
 
-#: src/containers/execution-environment-list/execution_environment_list.tsx:195
+#: src/containers/execution-environment-list/execution_environment_list.tsx:199
 msgid "No container repositories yet"
 msgstr "まだコンテナーリポジトリーはありません"
 
@@ -2302,7 +2302,7 @@ msgstr "拒否"
 msgid "Rejected"
 msgstr "拒否"
 
-#: src/containers/execution-environment-list/execution_environment_list.tsx:408
+#: src/containers/execution-environment-list/execution_environment_list.tsx:411
 #: src/containers/repositories/repository-list.tsx:119
 msgid "Remote"
 msgstr "リモート"
@@ -2317,15 +2317,15 @@ msgstr "リモートレジストリー"
 msgid "Remote name"
 msgstr "リモート名"
 
-#: src/containers/execution-environment/registry-list.tsx:480
+#: src/containers/execution-environment/registry-list.tsx:482
 msgid "Remote registry \"{name}\" could not be deleted."
 msgstr "リモートレジストリー \"{name}\" を削除できませんでした。"
 
-#: src/containers/execution-environment/registry-list.tsx:513
+#: src/containers/execution-environment/registry-list.tsx:515
 msgid "Remote registry \"{name}\" could not be synced."
 msgstr "リモートレジストリー \"{name}\" を同期できませんでした。"
 
-#: src/containers/execution-environment/registry-list.tsx:471
+#: src/containers/execution-environment/registry-list.tsx:473
 msgid "Remote registry \"{name}\" has been successfully deleted."
 msgstr "リモートレジストリー \"{name}\" が正常に削除されました。"
 
@@ -2413,7 +2413,7 @@ msgid "Save"
 msgstr "保存"
 
 #: src/containers/execution-environment-detail/base.tsx:219
-#: src/containers/execution-environment-list/execution_environment_list.tsx:453
+#: src/containers/execution-environment-list/execution_environment_list.tsx:456
 msgid "Saved changes to execution environment \"{0}\"."
 msgstr "実行環境 \"{0}\" への変更を保存しました。"
 
@@ -2445,13 +2445,13 @@ msgstr "最後までスクロール"
 #~ msgid "Search my namespaces"
 #~ msgstr "Search my namespaces"
 
-#: src/containers/execution-environment/registry-list.tsx:499
+#: src/containers/execution-environment/registry-list.tsx:501
 #: src/containers/execution-environment-detail/base.tsx:334
-#: src/containers/execution-environment-list/execution_environment_list.tsx:534
+#: src/containers/execution-environment-list/execution_environment_list.tsx:537
 msgid "See the task management <0>detail page </0>for the status of this task."
 msgstr "このタスクのステータスについては、タスク管理の <0>詳細ページ</0> を参照してください。"
 
-#: src/containers/execution-environment/registry-list.tsx:528
+#: src/containers/execution-environment/registry-list.tsx:530
 msgid "See the task management <0>detail page</0>for the status of this task."
 msgstr "このタスクのステータスについては、タスク管理の <0>詳細ページ</0> を参照してください。"
 
@@ -2713,13 +2713,13 @@ msgid "Sync"
 msgstr "同期"
 
 #: src/containers/execution-environment-detail/base.tsx:345
-#: src/containers/execution-environment-list/execution_environment_list.tsx:544
+#: src/containers/execution-environment-list/execution_environment_list.tsx:547
 msgid "Sync failed for {name}"
 msgstr "{name} の同期に失敗しました"
 
-#: src/containers/execution-environment/registry-list.tsx:375
+#: src/containers/execution-environment/registry-list.tsx:376
 #: src/containers/execution-environment-detail/base.tsx:122
-#: src/containers/execution-environment-list/execution_environment_list.tsx:356
+#: src/containers/execution-environment-list/execution_environment_list.tsx:359
 msgid "Sync from registry"
 msgstr "レジストリーからの同期"
 
@@ -2729,11 +2729,11 @@ msgstr "レジストリーからの同期"
 #~ msgid "Sync initiated for {name}"
 #~ msgstr "Sync initiated for {name}"
 
-#: src/containers/execution-environment-list/execution_environment_list.tsx:529
+#: src/containers/execution-environment-list/execution_environment_list.tsx:532
 msgid "Sync started for execution environment \"{name}\"."
 msgstr "実行環境 \"{name}\" の同期が開始されました。"
 
-#: src/containers/execution-environment/registry-list.tsx:496
+#: src/containers/execution-environment/registry-list.tsx:498
 #: src/containers/execution-environment-detail/base.tsx:331
 msgid "Sync started for remote registry \"{name}\"."
 msgstr "リモートレジストリー \"{name}\" の同期が開始されました。"
@@ -3045,7 +3045,7 @@ msgstr "アップストリーム名"
 #: src/components/execution-environment/publish-to-controller-modal.tsx:279
 #: src/containers/execution-environment-detail/base.tsx:135
 #: src/containers/execution-environment-detail/execution_environment_detail_images.tsx:408
-#: src/containers/execution-environment-list/execution_environment_list.tsx:369
+#: src/containers/execution-environment-list/execution_environment_list.tsx:372
 msgid "Use in Controller"
 msgstr "コントローラーでの使用"
 
@@ -3311,7 +3311,7 @@ msgstr "SSO ユーザーです。トークンは <0/> に期限が切れます�
 msgid "You can can customize the Resources tab on your profile by entering custom markdown here."
 msgstr "ここでカスタムマークダウンを入力して、プロファイルのリソースタブをカスタマイズできます。"
 
-#: src/containers/execution-environment-list/execution_environment_list.tsx:196
+#: src/containers/execution-environment-list/execution_environment_list.tsx:200
 msgid "You currently have no container repositories. Add a container repository via the CLI to get started."
 msgstr "現在、コンテナーリポジトリーはありません。開始するには、CLI でコンテナーリポジトリーを追加します。"
 

--- a/locale/ko.po
+++ b/locale/ko.po
@@ -193,7 +193,7 @@ msgid "Add container repository"
 msgstr "컨테이너 리포지토리 추가"
 
 #: src/components/execution-environment/repository-form.tsx:152
-#: src/containers/execution-environment-list/execution_environment_list.tsx:155
+#: src/containers/execution-environment-list/execution_environment_list.tsx:157
 msgid "Add execution environment"
 msgstr "실행 환경 추가"
 
@@ -627,12 +627,12 @@ msgstr "컨테이너 이름에는 영숫자 문자 \".\", \"_\", \"-\" 및 최�
 msgid "Container namespace"
 msgstr "컨테이너 네임스페이스"
 
-#: src/containers/execution-environment-list/execution_environment_list.tsx:307
+#: src/containers/execution-environment-list/execution_environment_list.tsx:310
 msgid "Container registry type"
 msgstr "컨테이너 레지스트리 유형"
 
-#: src/containers/execution-environment-list/execution_environment_list.tsx:231
-#: src/containers/execution-environment-list/execution_environment_list.tsx:287
+#: src/containers/execution-environment-list/execution_environment_list.tsx:234
+#: src/containers/execution-environment-list/execution_environment_list.tsx:290
 msgid "Container repository name"
 msgstr "컨테이너 리포지터리 이름"
 
@@ -715,7 +715,7 @@ msgid "Create new user"
 msgstr "새 사용자 만들기"
 
 #: src/containers/execution-environment/registry-list.tsx:327
-#: src/containers/execution-environment-list/execution_environment_list.tsx:297
+#: src/containers/execution-environment-list/execution_environment_list.tsx:300
 #: src/containers/group-management/group-detail.tsx:824
 #: src/containers/user-management/user-list.tsx:286
 msgid "Created"
@@ -767,10 +767,10 @@ msgid "Date created"
 msgstr "생성된 날짜"
 
 #: src/components/delete-modal/delete-modal.tsx:29
-#: src/containers/execution-environment/registry-list.tsx:406
+#: src/containers/execution-environment/registry-list.tsx:408
 #: src/containers/execution-environment-detail/base.tsx:144
 #: src/containers/execution-environment-detail/execution_environment_detail_images.tsx:416
-#: src/containers/execution-environment-list/execution_environment_list.tsx:378
+#: src/containers/execution-environment-list/execution_environment_list.tsx:381
 #: src/containers/group-management/group-detail.tsx:272
 #: src/containers/group-management/group-list.tsx:434
 #: src/containers/task-management/task-list-view.tsx:313
@@ -952,7 +952,7 @@ msgstr ""
 #: src/components/execution-environment/repository-form.tsx:368
 #: src/components/namespace-form/namespace-form.tsx:152
 #: src/components/role-list-table/role-list-table.tsx:49
-#: src/containers/execution-environment-list/execution_environment_list.tsx:292
+#: src/containers/execution-environment-list/execution_environment_list.tsx:295
 #: src/containers/task-management/task_detail.tsx:342
 msgid "Description"
 msgstr "설명"
@@ -1034,10 +1034,10 @@ msgstr "드롭다운"
 
 #: src/components/repositories/remote-repository-table.tsx:128
 #: src/containers/edit-namespace/edit-namespace.tsx:152
-#: src/containers/execution-environment/registry-list.tsx:393
+#: src/containers/execution-environment/registry-list.tsx:395
 #: src/containers/execution-environment-detail/base.tsx:194
 #: src/containers/execution-environment-detail/execution_environment_detail.tsx:99
-#: src/containers/execution-environment-list/execution_environment_list.tsx:351
+#: src/containers/execution-environment-list/execution_environment_list.tsx:354
 #: src/containers/group-management/group-detail.tsx:360
 #: src/containers/group-management/group-list.tsx:420
 #: src/containers/settings/user-profile.tsx:96
@@ -1153,7 +1153,7 @@ msgstr "API에서 가져오는 동안 오류 발생"
 #~ msgid "Error loading dependent collections."
 #~ msgstr "Error loading dependent collections."
 
-#: src/containers/execution-environment-list/execution_environment_list.tsx:498
+#: src/containers/execution-environment-list/execution_environment_list.tsx:501
 msgid "Error loading environments."
 msgstr "환경을 로드하는 동안 오류가 발생했습니다."
 
@@ -1267,18 +1267,18 @@ msgid "Execution Environment"
 msgstr "실행 환경"
 
 #: src/components/execution-environment-header/execution-environment-header.tsx:36
-#: src/containers/execution-environment-list/execution_environment_list.tsx:173
+#: src/containers/execution-environment-list/execution_environment_list.tsx:177
 #: src/containers/execution-environment-manifest/execution-environment-manifest.tsx:107
 #: src/loaders/standalone/standalone-loader.tsx:370
 #: src/loaders/standalone/standalone-loader.tsx:376
 msgid "Execution Environments"
 msgstr "실행 환경"
 
-#: src/containers/execution-environment-list/execution_environment_list.tsx:448
+#: src/containers/execution-environment-list/execution_environment_list.tsx:451
 msgid "Execution environment \"{0}\" has been added successfully."
 msgstr ""
 
-#: src/containers/execution-environment/registry-list.tsx:541
+#: src/containers/execution-environment/registry-list.tsx:543
 msgid "Execution environment \"{name}\" could not be indexed."
 msgstr "실행 환경 \"{name}\"을/를 인덱싱할 수 없습니다."
 
@@ -1361,7 +1361,7 @@ msgstr "{0}으로 필터링"
 msgid "Find content"
 msgstr "콘텐츠 검색"
 
-#: src/containers/execution-environment/registry-list.tsx:413
+#: src/containers/execution-environment/registry-list.tsx:415
 msgid "Find execution environments in this registry"
 msgstr "이 레지스트리에서 실행 환경 찾기"
 
@@ -1515,7 +1515,7 @@ msgstr "로그 가져오기"
 msgid "Imports"
 msgstr "가져오기"
 
-#: src/containers/execution-environment/registry-list.tsx:421
+#: src/containers/execution-environment/registry-list.tsx:423
 msgid "Index execution environments"
 msgstr "인덱스 실행 환경"
 
@@ -1523,7 +1523,7 @@ msgstr "인덱스 실행 환경"
 #~ msgid "Indexing execution environments in {name}"
 #~ msgstr "Indexing execution environments in {name}"
 
-#: src/containers/execution-environment/registry-list.tsx:414
+#: src/containers/execution-environment/registry-list.tsx:416
 msgid "Indexing execution environments is only supported on registry.redhat.io"
 msgstr "인덱스 실행 환경은 registry.redhat.io에서만 지원됩니다."
 
@@ -1531,7 +1531,7 @@ msgstr "인덱스 실행 환경은 registry.redhat.io에서만 지원됩니다."
 #~ msgid "Indexing failed for {name}"
 #~ msgstr "Indexing failed for {name}"
 
-#: src/containers/execution-environment/registry-list.tsx:525
+#: src/containers/execution-environment/registry-list.tsx:527
 msgid "Indexing started for execution environment \"{name}\"."
 msgstr "실행 환경 \"{name}\"에 대한 인덱싱이 시작되었습니다."
 
@@ -1588,7 +1588,7 @@ msgstr "이 창을 닫는 것이 안전합니다. 이러한 작업은 백그라�
 msgid "Keywords"
 msgstr "키워드"
 
-#: src/containers/execution-environment-list/execution_environment_list.tsx:302
+#: src/containers/execution-environment-list/execution_environment_list.tsx:305
 msgid "Last modified"
 msgstr "마지막으로 변경된 사항"
 
@@ -1653,7 +1653,7 @@ msgstr "컬렉션 목록"
 msgid "Load token"
 msgstr "토큰 로드"
 
-#: src/containers/execution-environment-list/execution_environment_list.tsx:408
+#: src/containers/execution-environment-list/execution_environment_list.tsx:411
 #: src/containers/repositories/repository-list.tsx:118
 msgid "Local"
 msgstr "지역"
@@ -1846,7 +1846,7 @@ msgstr "하위 작업 없음"
 msgid "No collections yet"
 msgstr "아직 컬렉션이 없습니다."
 
-#: src/containers/execution-environment-list/execution_environment_list.tsx:195
+#: src/containers/execution-environment-list/execution_environment_list.tsx:199
 msgid "No container repositories yet"
 msgstr "아직 컨테이너 리포지토리가 없음"
 
@@ -2302,7 +2302,7 @@ msgstr "거부"
 msgid "Rejected"
 msgstr "거부됨"
 
-#: src/containers/execution-environment-list/execution_environment_list.tsx:408
+#: src/containers/execution-environment-list/execution_environment_list.tsx:411
 #: src/containers/repositories/repository-list.tsx:119
 msgid "Remote"
 msgstr "원격"
@@ -2317,15 +2317,15 @@ msgstr "원격 레지스트리"
 msgid "Remote name"
 msgstr "원격 이름"
 
-#: src/containers/execution-environment/registry-list.tsx:480
+#: src/containers/execution-environment/registry-list.tsx:482
 msgid "Remote registry \"{name}\" could not be deleted."
 msgstr "원격 레지스트리 \"{name}\"은/는 삭제할 수 없습니다."
 
-#: src/containers/execution-environment/registry-list.tsx:513
+#: src/containers/execution-environment/registry-list.tsx:515
 msgid "Remote registry \"{name}\" could not be synced."
 msgstr "원격 레지스트리 \"{name}\"을/를 동기화할 수 없습니다."
 
-#: src/containers/execution-environment/registry-list.tsx:471
+#: src/containers/execution-environment/registry-list.tsx:473
 msgid "Remote registry \"{name}\" has been successfully deleted."
 msgstr "원격 레지스트리 \"{name}\"을/를 성공적으로 삭제했습니다"
 
@@ -2413,7 +2413,7 @@ msgid "Save"
 msgstr "저장"
 
 #: src/containers/execution-environment-detail/base.tsx:219
-#: src/containers/execution-environment-list/execution_environment_list.tsx:453
+#: src/containers/execution-environment-list/execution_environment_list.tsx:456
 msgid "Saved changes to execution environment \"{0}\"."
 msgstr "실행 환경 \"{0}\"에 대한 변경 사항을 저장했습니다."
 
@@ -2445,13 +2445,13 @@ msgstr "끝까지 스크롤"
 #~ msgid "Search my namespaces"
 #~ msgstr "Search my namespaces"
 
-#: src/containers/execution-environment/registry-list.tsx:499
+#: src/containers/execution-environment/registry-list.tsx:501
 #: src/containers/execution-environment-detail/base.tsx:334
-#: src/containers/execution-environment-list/execution_environment_list.tsx:534
+#: src/containers/execution-environment-list/execution_environment_list.tsx:537
 msgid "See the task management <0>detail page </0>for the status of this task."
 msgstr "이 작업의 상태에 대해서는 작업 관리 <0>세부 정보 페이지 </0>를 참조하십시오."
 
-#: src/containers/execution-environment/registry-list.tsx:528
+#: src/containers/execution-environment/registry-list.tsx:530
 msgid "See the task management <0>detail page</0>for the status of this task."
 msgstr "이 작업의 상태에 대해서는 작업 관리 <0>세부 정보 페이지</0>를 참조하십시오."
 
@@ -2713,13 +2713,13 @@ msgid "Sync"
 msgstr "동기화"
 
 #: src/containers/execution-environment-detail/base.tsx:345
-#: src/containers/execution-environment-list/execution_environment_list.tsx:544
+#: src/containers/execution-environment-list/execution_environment_list.tsx:547
 msgid "Sync failed for {name}"
 msgstr "{name}에 대한 동기화 실패"
 
-#: src/containers/execution-environment/registry-list.tsx:375
+#: src/containers/execution-environment/registry-list.tsx:376
 #: src/containers/execution-environment-detail/base.tsx:122
-#: src/containers/execution-environment-list/execution_environment_list.tsx:356
+#: src/containers/execution-environment-list/execution_environment_list.tsx:359
 msgid "Sync from registry"
 msgstr "레지스트리에서 동기화"
 
@@ -2729,11 +2729,11 @@ msgstr "레지스트리에서 동기화"
 #~ msgid "Sync initiated for {name}"
 #~ msgstr "Sync initiated for {name}"
 
-#: src/containers/execution-environment-list/execution_environment_list.tsx:529
+#: src/containers/execution-environment-list/execution_environment_list.tsx:532
 msgid "Sync started for execution environment \"{name}\"."
 msgstr "실행 환경 \"{name}\"에 대한 동기화가 시작되었습니다."
 
-#: src/containers/execution-environment/registry-list.tsx:496
+#: src/containers/execution-environment/registry-list.tsx:498
 #: src/containers/execution-environment-detail/base.tsx:331
 msgid "Sync started for remote registry \"{name}\"."
 msgstr "원격 레지스트리 \"{name}\"에 대한 동기화가 시작되었습니다."
@@ -3045,7 +3045,7 @@ msgstr "업스트림 이름"
 #: src/components/execution-environment/publish-to-controller-modal.tsx:279
 #: src/containers/execution-environment-detail/base.tsx:135
 #: src/containers/execution-environment-detail/execution_environment_detail_images.tsx:408
-#: src/containers/execution-environment-list/execution_environment_list.tsx:369
+#: src/containers/execution-environment-list/execution_environment_list.tsx:372
 msgid "Use in Controller"
 msgstr "컨트롤러에서 사용"
 
@@ -3311,7 +3311,7 @@ msgstr "SSO 사용자입니다. 토큰은 <0/> 만료됩니다."
 msgid "You can can customize the Resources tab on your profile by entering custom markdown here."
 msgstr "여기에서 사용자 정의 마크다운을 입력하여 프로필의 리소스 탭을 사용자 지정할 수 있습니다."
 
-#: src/containers/execution-environment-list/execution_environment_list.tsx:196
+#: src/containers/execution-environment-list/execution_environment_list.tsx:200
 msgid "You currently have no container repositories. Add a container repository via the CLI to get started."
 msgstr "현재 컨테이너 리포지토리가 없습니다. 시작하려면 CLI를 통해 컨테이너 리포지토리를 추가합니다."
 

--- a/locale/nl.po
+++ b/locale/nl.po
@@ -193,7 +193,7 @@ msgid "Add container repository"
 msgstr "Container-repository toevoegen"
 
 #: src/components/execution-environment/repository-form.tsx:152
-#: src/containers/execution-environment-list/execution_environment_list.tsx:155
+#: src/containers/execution-environment-list/execution_environment_list.tsx:157
 msgid "Add execution environment"
 msgstr "Uitvoeringsomgeving toevoegen"
 
@@ -629,12 +629,12 @@ msgstr "Containernamen kunnen alleen alfanumerieke tekens, \".\", \"_\", \"-\" e
 msgid "Container namespace"
 msgstr "Container-namespace"
 
-#: src/containers/execution-environment-list/execution_environment_list.tsx:307
+#: src/containers/execution-environment-list/execution_environment_list.tsx:310
 msgid "Container registry type"
 msgstr "Type containerregister"
 
-#: src/containers/execution-environment-list/execution_environment_list.tsx:231
-#: src/containers/execution-environment-list/execution_environment_list.tsx:287
+#: src/containers/execution-environment-list/execution_environment_list.tsx:234
+#: src/containers/execution-environment-list/execution_environment_list.tsx:290
 msgid "Container repository name"
 msgstr "Naam container-repository"
 
@@ -717,7 +717,7 @@ msgid "Create new user"
 msgstr "Nieuwe gebruiker maken"
 
 #: src/containers/execution-environment/registry-list.tsx:327
-#: src/containers/execution-environment-list/execution_environment_list.tsx:297
+#: src/containers/execution-environment-list/execution_environment_list.tsx:300
 #: src/containers/group-management/group-detail.tsx:824
 #: src/containers/user-management/user-list.tsx:286
 msgid "Created"
@@ -769,10 +769,10 @@ msgid "Date created"
 msgstr "Datum aangemaakt"
 
 #: src/components/delete-modal/delete-modal.tsx:29
-#: src/containers/execution-environment/registry-list.tsx:406
+#: src/containers/execution-environment/registry-list.tsx:408
 #: src/containers/execution-environment-detail/base.tsx:144
 #: src/containers/execution-environment-detail/execution_environment_detail_images.tsx:416
-#: src/containers/execution-environment-list/execution_environment_list.tsx:378
+#: src/containers/execution-environment-list/execution_environment_list.tsx:381
 #: src/containers/group-management/group-detail.tsx:272
 #: src/containers/group-management/group-list.tsx:434
 #: src/containers/task-management/task-list-view.tsx:313
@@ -954,7 +954,7 @@ msgstr ""
 #: src/components/execution-environment/repository-form.tsx:368
 #: src/components/namespace-form/namespace-form.tsx:152
 #: src/components/role-list-table/role-list-table.tsx:49
-#: src/containers/execution-environment-list/execution_environment_list.tsx:292
+#: src/containers/execution-environment-list/execution_environment_list.tsx:295
 #: src/containers/task-management/task_detail.tsx:342
 msgid "Description"
 msgstr "Omschrijving"
@@ -1036,10 +1036,10 @@ msgstr "Dropdown"
 
 #: src/components/repositories/remote-repository-table.tsx:128
 #: src/containers/edit-namespace/edit-namespace.tsx:152
-#: src/containers/execution-environment/registry-list.tsx:393
+#: src/containers/execution-environment/registry-list.tsx:395
 #: src/containers/execution-environment-detail/base.tsx:194
 #: src/containers/execution-environment-detail/execution_environment_detail.tsx:99
-#: src/containers/execution-environment-list/execution_environment_list.tsx:351
+#: src/containers/execution-environment-list/execution_environment_list.tsx:354
 #: src/containers/group-management/group-detail.tsx:360
 #: src/containers/group-management/group-list.tsx:420
 #: src/containers/settings/user-profile.tsx:96
@@ -1155,7 +1155,7 @@ msgstr "Fout bij ophalen import uit API"
 #~ msgid "Error loading dependent collections."
 #~ msgstr "Error loading dependent collections."
 
-#: src/containers/execution-environment-list/execution_environment_list.tsx:498
+#: src/containers/execution-environment-list/execution_environment_list.tsx:501
 msgid "Error loading environments."
 msgstr "Fout bij het laden van omgevingen."
 
@@ -1269,18 +1269,18 @@ msgid "Execution Environment"
 msgstr "Uitvoeringsomgeving"
 
 #: src/components/execution-environment-header/execution-environment-header.tsx:36
-#: src/containers/execution-environment-list/execution_environment_list.tsx:173
+#: src/containers/execution-environment-list/execution_environment_list.tsx:177
 #: src/containers/execution-environment-manifest/execution-environment-manifest.tsx:107
 #: src/loaders/standalone/standalone-loader.tsx:370
 #: src/loaders/standalone/standalone-loader.tsx:376
 msgid "Execution Environments"
 msgstr "Uitvoeringsomgevingen"
 
-#: src/containers/execution-environment-list/execution_environment_list.tsx:448
+#: src/containers/execution-environment-list/execution_environment_list.tsx:451
 msgid "Execution environment \"{0}\" has been added successfully."
 msgstr ""
 
-#: src/containers/execution-environment/registry-list.tsx:541
+#: src/containers/execution-environment/registry-list.tsx:543
 msgid "Execution environment \"{name}\" could not be indexed."
 msgstr "Execution environment \"{name}\" could not be indexed."
 
@@ -1363,7 +1363,7 @@ msgstr "Filteren op {0}"
 msgid "Find content"
 msgstr "Inhoud zoeken"
 
-#: src/containers/execution-environment/registry-list.tsx:413
+#: src/containers/execution-environment/registry-list.tsx:415
 msgid "Find execution environments in this registry"
 msgstr "Uitvoeringsomgevingen in dit register zoeken"
 
@@ -1517,7 +1517,7 @@ msgstr "Logboek importeren"
 msgid "Imports"
 msgstr "Invoer"
 
-#: src/containers/execution-environment/registry-list.tsx:421
+#: src/containers/execution-environment/registry-list.tsx:423
 msgid "Index execution environments"
 msgstr "Index uitvoeringsomgevingen"
 
@@ -1525,7 +1525,7 @@ msgstr "Index uitvoeringsomgevingen"
 #~ msgid "Indexing execution environments in {name}"
 #~ msgstr "Indexing execution environments in {name}"
 
-#: src/containers/execution-environment/registry-list.tsx:414
+#: src/containers/execution-environment/registry-list.tsx:416
 msgid "Indexing execution environments is only supported on registry.redhat.io"
 msgstr "Het indexeren van uitvoeringsomgevingen wordt alleen ondersteund op registry.redhat.io"
 
@@ -1533,7 +1533,7 @@ msgstr "Het indexeren van uitvoeringsomgevingen wordt alleen ondersteund op regi
 #~ msgid "Indexing failed for {name}"
 #~ msgstr "Indexing failed for {name}"
 
-#: src/containers/execution-environment/registry-list.tsx:525
+#: src/containers/execution-environment/registry-list.tsx:527
 msgid "Indexing started for execution environment \"{name}\"."
 msgstr "Indexing started for execution environment \"{name}\"."
 
@@ -1590,7 +1590,7 @@ msgstr "Het is veilig om dit venster te sluiten. Deze taken zullen op de achterg
 msgid "Keywords"
 msgstr "Trefwoorden"
 
-#: src/containers/execution-environment-list/execution_environment_list.tsx:302
+#: src/containers/execution-environment-list/execution_environment_list.tsx:305
 msgid "Last modified"
 msgstr "Laatste wijziging"
 
@@ -1655,7 +1655,7 @@ msgstr "Lijst van collecties"
 msgid "Load token"
 msgstr "Laadtoken"
 
-#: src/containers/execution-environment-list/execution_environment_list.tsx:408
+#: src/containers/execution-environment-list/execution_environment_list.tsx:411
 #: src/containers/repositories/repository-list.tsx:118
 msgid "Local"
 msgstr "Lokaal"
@@ -1848,7 +1848,7 @@ msgstr "Geen kindertaak"
 msgid "No collections yet"
 msgstr "Nog geen collecties"
 
-#: src/containers/execution-environment-list/execution_environment_list.tsx:195
+#: src/containers/execution-environment-list/execution_environment_list.tsx:199
 msgid "No container repositories yet"
 msgstr "Nog geen containerrepository's"
 
@@ -2304,7 +2304,7 @@ msgstr "Weigeren"
 msgid "Rejected"
 msgstr "Geweigerd"
 
-#: src/containers/execution-environment-list/execution_environment_list.tsx:408
+#: src/containers/execution-environment-list/execution_environment_list.tsx:411
 #: src/containers/repositories/repository-list.tsx:119
 msgid "Remote"
 msgstr "Afstand"
@@ -2319,15 +2319,15 @@ msgstr "Externe registers"
 msgid "Remote name"
 msgstr "Externe naam"
 
-#: src/containers/execution-environment/registry-list.tsx:480
+#: src/containers/execution-environment/registry-list.tsx:482
 msgid "Remote registry \"{name}\" could not be deleted."
 msgstr "Remote registry \"{name}\" could not be deleted."
 
-#: src/containers/execution-environment/registry-list.tsx:513
+#: src/containers/execution-environment/registry-list.tsx:515
 msgid "Remote registry \"{name}\" could not be synced."
 msgstr "Remote registry \"{name}\" could not be synced."
 
-#: src/containers/execution-environment/registry-list.tsx:471
+#: src/containers/execution-environment/registry-list.tsx:473
 msgid "Remote registry \"{name}\" has been successfully deleted."
 msgstr "Extern register {name} met succes verwijderd"
 
@@ -2415,7 +2415,7 @@ msgid "Save"
 msgstr "Opslaan"
 
 #: src/containers/execution-environment-detail/base.tsx:219
-#: src/containers/execution-environment-list/execution_environment_list.tsx:453
+#: src/containers/execution-environment-list/execution_environment_list.tsx:456
 msgid "Saved changes to execution environment \"{0}\"."
 msgstr "Terug naar uitvoeringsomgevingen \"{0}\""
 
@@ -2447,13 +2447,13 @@ msgstr "Bladeren naar het einde"
 #~ msgid "Search my namespaces"
 #~ msgstr "Search my namespaces"
 
-#: src/containers/execution-environment/registry-list.tsx:499
+#: src/containers/execution-environment/registry-list.tsx:501
 #: src/containers/execution-environment-detail/base.tsx:334
-#: src/containers/execution-environment-list/execution_environment_list.tsx:534
+#: src/containers/execution-environment-list/execution_environment_list.tsx:537
 msgid "See the task management <0>detail page </0>for the status of this task."
 msgstr "See the task management <0>detail page </0>for the status of this task."
 
-#: src/containers/execution-environment/registry-list.tsx:528
+#: src/containers/execution-environment/registry-list.tsx:530
 msgid "See the task management <0>detail page</0>for the status of this task."
 msgstr "See the task management <0>detail page</0>for the status of this task."
 
@@ -2715,13 +2715,13 @@ msgid "Sync"
 msgstr "Synchroniseren"
 
 #: src/containers/execution-environment-detail/base.tsx:345
-#: src/containers/execution-environment-list/execution_environment_list.tsx:544
+#: src/containers/execution-environment-list/execution_environment_list.tsx:547
 msgid "Sync failed for {name}"
 msgstr "Sync mislukt voor {name}"
 
-#: src/containers/execution-environment/registry-list.tsx:375
+#: src/containers/execution-environment/registry-list.tsx:376
 #: src/containers/execution-environment-detail/base.tsx:122
-#: src/containers/execution-environment-list/execution_environment_list.tsx:356
+#: src/containers/execution-environment-list/execution_environment_list.tsx:359
 msgid "Sync from registry"
 msgstr "Synchroniseren vanuit register"
 
@@ -2731,11 +2731,11 @@ msgstr "Synchroniseren vanuit register"
 #~ msgid "Sync initiated for {name}"
 #~ msgstr "Sync initiated for {name}"
 
-#: src/containers/execution-environment-list/execution_environment_list.tsx:529
+#: src/containers/execution-environment-list/execution_environment_list.tsx:532
 msgid "Sync started for execution environment \"{name}\"."
 msgstr "Sync started for execution environment \"{name}\"."
 
-#: src/containers/execution-environment/registry-list.tsx:496
+#: src/containers/execution-environment/registry-list.tsx:498
 #: src/containers/execution-environment-detail/base.tsx:331
 msgid "Sync started for remote registry \"{name}\"."
 msgstr "Sync started for remote registry \"{name}\"."
@@ -3047,7 +3047,7 @@ msgstr "Naam stroomopwaarts"
 #: src/components/execution-environment/publish-to-controller-modal.tsx:279
 #: src/containers/execution-environment-detail/base.tsx:135
 #: src/containers/execution-environment-detail/execution_environment_detail_images.tsx:408
-#: src/containers/execution-environment-list/execution_environment_list.tsx:369
+#: src/containers/execution-environment-list/execution_environment_list.tsx:372
 msgid "Use in Controller"
 msgstr "Gebruiken in controller"
 
@@ -3313,7 +3313,7 @@ msgstr "U bent een SSO-gebruiker. Uw token zal verlopen <0/>."
 msgid "You can can customize the Resources tab on your profile by entering custom markdown here."
 msgstr "U kunt het tabblad Hulpbronnen op uw profiel aanpassen door hier aangepaste markdown in te voeren."
 
-#: src/containers/execution-environment-list/execution_environment_list.tsx:196
+#: src/containers/execution-environment-list/execution_environment_list.tsx:200
 msgid "You currently have no container repositories. Add a container repository via the CLI to get started."
 msgstr "U hebt momenteel geen containerrepository's. Voeg een containerrepository toe via de CLI om te beginnen."
 

--- a/locale/zh.po
+++ b/locale/zh.po
@@ -193,7 +193,7 @@ msgid "Add container repository"
 msgstr "添加容器仓库"
 
 #: src/components/execution-environment/repository-form.tsx:152
-#: src/containers/execution-environment-list/execution_environment_list.tsx:155
+#: src/containers/execution-environment-list/execution_environment_list.tsx:157
 msgid "Add execution environment"
 msgstr "添加执行环境"
 
@@ -627,12 +627,12 @@ msgstr "容器名称只能包含字母数字，\".\"、\"_\"、\"-\"，以及最
 msgid "Container namespace"
 msgstr "容器命名空间"
 
-#: src/containers/execution-environment-list/execution_environment_list.tsx:307
+#: src/containers/execution-environment-list/execution_environment_list.tsx:310
 msgid "Container registry type"
 msgstr "容器 Registry 类型"
 
-#: src/containers/execution-environment-list/execution_environment_list.tsx:231
-#: src/containers/execution-environment-list/execution_environment_list.tsx:287
+#: src/containers/execution-environment-list/execution_environment_list.tsx:234
+#: src/containers/execution-environment-list/execution_environment_list.tsx:290
 msgid "Container repository name"
 msgstr "容器仓库名称"
 
@@ -715,7 +715,7 @@ msgid "Create new user"
 msgstr "创建新用户"
 
 #: src/containers/execution-environment/registry-list.tsx:327
-#: src/containers/execution-environment-list/execution_environment_list.tsx:297
+#: src/containers/execution-environment-list/execution_environment_list.tsx:300
 #: src/containers/group-management/group-detail.tsx:824
 #: src/containers/user-management/user-list.tsx:286
 msgid "Created"
@@ -767,10 +767,10 @@ msgid "Date created"
 msgstr "创建日期"
 
 #: src/components/delete-modal/delete-modal.tsx:29
-#: src/containers/execution-environment/registry-list.tsx:406
+#: src/containers/execution-environment/registry-list.tsx:408
 #: src/containers/execution-environment-detail/base.tsx:144
 #: src/containers/execution-environment-detail/execution_environment_detail_images.tsx:416
-#: src/containers/execution-environment-list/execution_environment_list.tsx:378
+#: src/containers/execution-environment-list/execution_environment_list.tsx:381
 #: src/containers/group-management/group-detail.tsx:272
 #: src/containers/group-management/group-list.tsx:434
 #: src/containers/task-management/task-list-view.tsx:313
@@ -952,7 +952,7 @@ msgstr ""
 #: src/components/execution-environment/repository-form.tsx:368
 #: src/components/namespace-form/namespace-form.tsx:152
 #: src/components/role-list-table/role-list-table.tsx:49
-#: src/containers/execution-environment-list/execution_environment_list.tsx:292
+#: src/containers/execution-environment-list/execution_environment_list.tsx:295
 #: src/containers/task-management/task_detail.tsx:342
 msgid "Description"
 msgstr "描述"
@@ -1034,10 +1034,10 @@ msgstr "下拉菜单"
 
 #: src/components/repositories/remote-repository-table.tsx:128
 #: src/containers/edit-namespace/edit-namespace.tsx:152
-#: src/containers/execution-environment/registry-list.tsx:393
+#: src/containers/execution-environment/registry-list.tsx:395
 #: src/containers/execution-environment-detail/base.tsx:194
 #: src/containers/execution-environment-detail/execution_environment_detail.tsx:99
-#: src/containers/execution-environment-list/execution_environment_list.tsx:351
+#: src/containers/execution-environment-list/execution_environment_list.tsx:354
 #: src/containers/group-management/group-detail.tsx:360
 #: src/containers/group-management/group-list.tsx:420
 #: src/containers/settings/user-profile.tsx:96
@@ -1153,7 +1153,7 @@ msgstr "从 API 获取导入时出错"
 #~ msgid "Error loading dependent collections."
 #~ msgstr "Error loading dependent collections."
 
-#: src/containers/execution-environment-list/execution_environment_list.tsx:498
+#: src/containers/execution-environment-list/execution_environment_list.tsx:501
 msgid "Error loading environments."
 msgstr "加载环境时出错。"
 
@@ -1267,18 +1267,18 @@ msgid "Execution Environment"
 msgstr "执行环境"
 
 #: src/components/execution-environment-header/execution-environment-header.tsx:36
-#: src/containers/execution-environment-list/execution_environment_list.tsx:173
+#: src/containers/execution-environment-list/execution_environment_list.tsx:177
 #: src/containers/execution-environment-manifest/execution-environment-manifest.tsx:107
 #: src/loaders/standalone/standalone-loader.tsx:370
 #: src/loaders/standalone/standalone-loader.tsx:376
 msgid "Execution Environments"
 msgstr "执行环境"
 
-#: src/containers/execution-environment-list/execution_environment_list.tsx:448
+#: src/containers/execution-environment-list/execution_environment_list.tsx:451
 msgid "Execution environment \"{0}\" has been added successfully."
 msgstr ""
 
-#: src/containers/execution-environment/registry-list.tsx:541
+#: src/containers/execution-environment/registry-list.tsx:543
 msgid "Execution environment \"{name}\" could not be indexed."
 msgstr "执行环境 \"{name}\" 无法被索引。"
 
@@ -1361,7 +1361,7 @@ msgstr "按 {0} 过滤。"
 msgid "Find content"
 msgstr "查找内容"
 
-#: src/containers/execution-environment/registry-list.tsx:413
+#: src/containers/execution-environment/registry-list.tsx:415
 msgid "Find execution environments in this registry"
 msgstr "在此 registry 中查找执行环境"
 
@@ -1515,7 +1515,7 @@ msgstr "导入日志"
 msgid "Imports"
 msgstr "导入"
 
-#: src/containers/execution-environment/registry-list.tsx:421
+#: src/containers/execution-environment/registry-list.tsx:423
 msgid "Index execution environments"
 msgstr "索引执行环境"
 
@@ -1523,7 +1523,7 @@ msgstr "索引执行环境"
 #~ msgid "Indexing execution environments in {name}"
 #~ msgstr "Indexing execution environments in {name}"
 
-#: src/containers/execution-environment/registry-list.tsx:414
+#: src/containers/execution-environment/registry-list.tsx:416
 msgid "Indexing execution environments is only supported on registry.redhat.io"
 msgstr "只有在 registry.redhat.io 上才支持索引执行环境"
 
@@ -1531,7 +1531,7 @@ msgstr "只有在 registry.redhat.io 上才支持索引执行环境"
 #~ msgid "Indexing failed for {name}"
 #~ msgstr "Indexing failed for {name}"
 
-#: src/containers/execution-environment/registry-list.tsx:525
+#: src/containers/execution-environment/registry-list.tsx:527
 msgid "Indexing started for execution environment \"{name}\"."
 msgstr "为执行环境 \"{name}\" 执行索引已开始。"
 
@@ -1588,7 +1588,7 @@ msgstr "关闭这个窗口是安全的。这些任务将在后台结束。"
 msgid "Keywords"
 msgstr "关键字"
 
-#: src/containers/execution-environment-list/execution_environment_list.tsx:302
+#: src/containers/execution-environment-list/execution_environment_list.tsx:305
 msgid "Last modified"
 msgstr "最后修改"
 
@@ -1653,7 +1653,7 @@ msgstr "集合列表"
 msgid "Load token"
 msgstr "加载令牌"
 
-#: src/containers/execution-environment-list/execution_environment_list.tsx:408
+#: src/containers/execution-environment-list/execution_environment_list.tsx:411
 #: src/containers/repositories/repository-list.tsx:118
 msgid "Local"
 msgstr "本地"
@@ -1846,7 +1846,7 @@ msgstr "没有子任务"
 msgid "No collections yet"
 msgstr "还没有集合"
 
-#: src/containers/execution-environment-list/execution_environment_list.tsx:195
+#: src/containers/execution-environment-list/execution_environment_list.tsx:199
 msgid "No container repositories yet"
 msgstr "还没有容器仓库"
 
@@ -2302,7 +2302,7 @@ msgstr "拒绝"
 msgid "Rejected"
 msgstr "拒绝"
 
-#: src/containers/execution-environment-list/execution_environment_list.tsx:408
+#: src/containers/execution-environment-list/execution_environment_list.tsx:411
 #: src/containers/repositories/repository-list.tsx:119
 msgid "Remote"
 msgstr "远程"
@@ -2317,15 +2317,15 @@ msgstr "远程 Registry"
 msgid "Remote name"
 msgstr "远程名称"
 
-#: src/containers/execution-environment/registry-list.tsx:480
+#: src/containers/execution-environment/registry-list.tsx:482
 msgid "Remote registry \"{name}\" could not be deleted."
 msgstr "远程 registry \"{name}\" 无法删除。"
 
-#: src/containers/execution-environment/registry-list.tsx:513
+#: src/containers/execution-environment/registry-list.tsx:515
 msgid "Remote registry \"{name}\" could not be synced."
 msgstr "远程 registry \"{name}\" 无法同步。"
 
-#: src/containers/execution-environment/registry-list.tsx:471
+#: src/containers/execution-environment/registry-list.tsx:473
 msgid "Remote registry \"{name}\" has been successfully deleted."
 msgstr "远程 \"{name}\" 已被成功删除。"
 
@@ -2413,7 +2413,7 @@ msgid "Save"
 msgstr "保存"
 
 #: src/containers/execution-environment-detail/base.tsx:219
-#: src/containers/execution-environment-list/execution_environment_list.tsx:453
+#: src/containers/execution-environment-list/execution_environment_list.tsx:456
 msgid "Saved changes to execution environment \"{0}\"."
 msgstr "已保存对执行环境 \"{0}\" 的变化。"
 
@@ -2445,13 +2445,13 @@ msgstr "滚动至末尾"
 #~ msgid "Search my namespaces"
 #~ msgstr "Search my namespaces"
 
-#: src/containers/execution-environment/registry-list.tsx:499
+#: src/containers/execution-environment/registry-list.tsx:501
 #: src/containers/execution-environment-detail/base.tsx:334
-#: src/containers/execution-environment-list/execution_environment_list.tsx:534
+#: src/containers/execution-environment-list/execution_environment_list.tsx:537
 msgid "See the task management <0>detail page </0>for the status of this task."
 msgstr "有关此任务的状态，请参阅任务管理<0>详情页</0>。"
 
-#: src/containers/execution-environment/registry-list.tsx:528
+#: src/containers/execution-environment/registry-list.tsx:530
 msgid "See the task management <0>detail page</0>for the status of this task."
 msgstr "有关此任务的状态，请参阅任务管理<0>详情页</0>。"
 
@@ -2713,13 +2713,13 @@ msgid "Sync"
 msgstr "同步"
 
 #: src/containers/execution-environment-detail/base.tsx:345
-#: src/containers/execution-environment-list/execution_environment_list.tsx:544
+#: src/containers/execution-environment-list/execution_environment_list.tsx:547
 msgid "Sync failed for {name}"
 msgstr "为 {name} 同步失败"
 
-#: src/containers/execution-environment/registry-list.tsx:375
+#: src/containers/execution-environment/registry-list.tsx:376
 #: src/containers/execution-environment-detail/base.tsx:122
-#: src/containers/execution-environment-list/execution_environment_list.tsx:356
+#: src/containers/execution-environment-list/execution_environment_list.tsx:359
 msgid "Sync from registry"
 msgstr "从 registry 进行同步"
 
@@ -2729,11 +2729,11 @@ msgstr "从 registry 进行同步"
 #~ msgid "Sync initiated for {name}"
 #~ msgstr "Sync initiated for {name}"
 
-#: src/containers/execution-environment-list/execution_environment_list.tsx:529
+#: src/containers/execution-environment-list/execution_environment_list.tsx:532
 msgid "Sync started for execution environment \"{name}\"."
 msgstr "执行环境 \"{name}\" 的同步开始。"
 
-#: src/containers/execution-environment/registry-list.tsx:496
+#: src/containers/execution-environment/registry-list.tsx:498
 #: src/containers/execution-environment-detail/base.tsx:331
 msgid "Sync started for remote registry \"{name}\"."
 msgstr "远程 registry \"{name}\" 的同步开始。"
@@ -3045,7 +3045,7 @@ msgstr "上游名称"
 #: src/components/execution-environment/publish-to-controller-modal.tsx:279
 #: src/containers/execution-environment-detail/base.tsx:135
 #: src/containers/execution-environment-detail/execution_environment_detail_images.tsx:408
-#: src/containers/execution-environment-list/execution_environment_list.tsx:369
+#: src/containers/execution-environment-list/execution_environment_list.tsx:372
 msgid "Use in Controller"
 msgstr "在控制器中使用"
 
@@ -3311,7 +3311,7 @@ msgstr "您是一个 SSO 用户。您的令牌将过期 <0/>。"
 msgid "You can can customize the Resources tab on your profile by entering custom markdown here."
 msgstr "您可以通过在此处输入自定义标记来自定义配置集上的 Resources 选项卡。"
 
-#: src/containers/execution-environment-list/execution_environment_list.tsx:196
+#: src/containers/execution-environment-list/execution_environment_list.tsx:200
 msgid "You currently have no container repositories. Add a container repository via the CLI to get started."
 msgstr "您当前没有容器仓库。通过 CLI 添加容器仓库以开始。"
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -35,9 +35,9 @@
             "dev": true
         },
         "@babel/core": {
-            "version": "7.18.2",
-            "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.18.2.tgz",
-            "integrity": "sha512-A8pri1YJiC5UnkdrWcmfZTJTV85b4UXTAfImGmCfYmax4TR9Cw8sDS0MOk++Gp2mE/BefVJ5nwy5yzqNJbP/DQ==",
+            "version": "7.18.5",
+            "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.18.5.tgz",
+            "integrity": "sha512-MGY8vg3DxMnctw0LdvSEojOsumc70g0t18gNyUdAZqB1Rpd1Bqo/svHGvt+UJ6JcGX+DIekGFDxxIWofBxLCnQ==",
             "dev": true,
             "requires": {
                 "@ampproject/remapping": "^2.1.0",
@@ -46,10 +46,10 @@
                 "@babel/helper-compilation-targets": "^7.18.2",
                 "@babel/helper-module-transforms": "^7.18.0",
                 "@babel/helpers": "^7.18.2",
-                "@babel/parser": "^7.18.0",
+                "@babel/parser": "^7.18.5",
                 "@babel/template": "^7.16.7",
-                "@babel/traverse": "^7.18.2",
-                "@babel/types": "^7.18.2",
+                "@babel/traverse": "^7.18.5",
+                "@babel/types": "^7.18.4",
                 "convert-source-map": "^1.7.0",
                 "debug": "^4.1.0",
                 "gensync": "^1.0.0-beta.2",
@@ -67,9 +67,9 @@
                     }
                 },
                 "@babel/compat-data": {
-                    "version": "7.17.10",
-                    "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.17.10.tgz",
-                    "integrity": "sha512-GZt/TCsG70Ms19gfZO1tM4CVnXsPgEPBCpJu+Qz3L0LUDsY5nZqFZglIoPC1kIYOtNBZlrnFT+klg12vFGZXrw==",
+                    "version": "7.18.5",
+                    "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.18.5.tgz",
+                    "integrity": "sha512-BxhE40PVCBxVEJsSBhB6UWyAuqJRxGsAw8BdHMJ3AKGydcwuWW4kOO3HmqBQAdcq/OP+/DlTVxLvsCzRTnZuGg==",
                     "dev": true
                 },
                 "@babel/generator": {
@@ -147,9 +147,9 @@
                     }
                 },
                 "@babel/parser": {
-                    "version": "7.18.4",
-                    "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.18.4.tgz",
-                    "integrity": "sha512-FDge0dFazETFcxGw/EXzOkN8uJp0PC7Qbm+Pe9T+av2zlBpOgunFHkQPPn+eRuClU73JF+98D531UgayY89tow==",
+                    "version": "7.18.5",
+                    "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.18.5.tgz",
+                    "integrity": "sha512-YZWVaglMiplo7v8f1oMQ5ZPQr0vn7HPeZXxXWsxXJRjGVrzUFn9OxFQl1sb5wzfootjA/yChhW84BV+383FSOw==",
                     "dev": true
                 },
                 "@babel/template": {
@@ -164,9 +164,9 @@
                     }
                 },
                 "@babel/traverse": {
-                    "version": "7.18.2",
-                    "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.18.2.tgz",
-                    "integrity": "sha512-9eNwoeovJ6KH9zcCNnENY7DMFwTU9JdGCFtqNLfUAqtUHRCOsTOqWoffosP8vKmNYeSBUv3yVJXjfd8ucwOjUA==",
+                    "version": "7.18.5",
+                    "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.18.5.tgz",
+                    "integrity": "sha512-aKXj1KT66sBj0vVzk6rEeAO6Z9aiiQ68wfDgge3nHhA/my6xMM/7HGQUNumKZaoa2qUPQ5whJG9aAifsxUKfLA==",
                     "dev": true,
                     "requires": {
                         "@babel/code-frame": "^7.16.7",
@@ -175,8 +175,8 @@
                         "@babel/helper-function-name": "^7.17.9",
                         "@babel/helper-hoist-variables": "^7.16.7",
                         "@babel/helper-split-export-declaration": "^7.16.7",
-                        "@babel/parser": "^7.18.0",
-                        "@babel/types": "^7.18.2",
+                        "@babel/parser": "^7.18.5",
+                        "@babel/types": "^7.18.4",
                         "debug": "^4.1.0",
                         "globals": "^11.1.0"
                     }
@@ -203,34 +203,28 @@
                     }
                 },
                 "browserslist": {
-                    "version": "4.20.3",
-                    "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.20.3.tgz",
-                    "integrity": "sha512-NBhymBQl1zM0Y5dQT/O+xiLP9/rzOIQdKM/eMJBAq7yBgaB6krIYLGejrwVYnSHZdqjscB1SPuAjHwxjvN6Wdg==",
+                    "version": "4.20.4",
+                    "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.20.4.tgz",
+                    "integrity": "sha512-ok1d+1WpnU24XYN7oC3QWgTyMhY/avPJ/r9T00xxvUOIparA/gc+UPUMaod3i+G6s+nI2nUb9xZ5k794uIwShw==",
                     "dev": true,
                     "requires": {
-                        "caniuse-lite": "^1.0.30001332",
-                        "electron-to-chromium": "^1.4.118",
+                        "caniuse-lite": "^1.0.30001349",
+                        "electron-to-chromium": "^1.4.147",
                         "escalade": "^3.1.1",
-                        "node-releases": "^2.0.3",
+                        "node-releases": "^2.0.5",
                         "picocolors": "^1.0.0"
                     }
                 },
                 "caniuse-lite": {
-                    "version": "1.0.30001344",
-                    "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001344.tgz",
-                    "integrity": "sha512-0ZFjnlCaXNOAYcV7i+TtdKBp0L/3XEU2MF/x6Du1lrh+SRX4IfzIVL4HNJg5pB2PmFb8rszIGyOvsZnqqRoc2g==",
+                    "version": "1.0.30001356",
+                    "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001356.tgz",
+                    "integrity": "sha512-/30854bktMLhxtjieIxsrJBfs2gTM1pel6MXKF3K+RdIVJZcsn2A2QdhsuR4/p9+R204fZw0zCBBhktX8xWuyQ==",
                     "dev": true
                 },
                 "electron-to-chromium": {
-                    "version": "1.4.141",
-                    "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.141.tgz",
-                    "integrity": "sha512-mfBcbqc0qc6RlxrsIgLG2wCqkiPAjEezHxGTu7p3dHHFOurH4EjS9rFZndX5axC8264rI1Pcbw8uQP39oZckeA==",
-                    "dev": true
-                },
-                "json5": {
-                    "version": "2.2.1",
-                    "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.1.tgz",
-                    "integrity": "sha512-1hqLFMSrGHRHxav9q9gNjJ5EXznIxGVO09xQRrwplcS8qs28pZ8s8hupZAmqDwZUmVZ2Qb2jnyPOWcDH8m8dlA==",
+                    "version": "1.4.161",
+                    "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.161.tgz",
+                    "integrity": "sha512-sTjBRhqh6wFodzZtc5Iu8/R95OkwaPNn7tj/TaDU5nu/5EFiQDtADGAXdR4tJcTEHlYfJpHqigzJqHvPgehP8A==",
                     "dev": true
                 },
                 "node-releases": {
@@ -660,9 +654,9 @@
                     }
                 },
                 "@babel/parser": {
-                    "version": "7.18.4",
-                    "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.18.4.tgz",
-                    "integrity": "sha512-FDge0dFazETFcxGw/EXzOkN8uJp0PC7Qbm+Pe9T+av2zlBpOgunFHkQPPn+eRuClU73JF+98D531UgayY89tow==",
+                    "version": "7.18.5",
+                    "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.18.5.tgz",
+                    "integrity": "sha512-YZWVaglMiplo7v8f1oMQ5ZPQr0vn7HPeZXxXWsxXJRjGVrzUFn9OxFQl1sb5wzfootjA/yChhW84BV+383FSOw==",
                     "dev": true
                 },
                 "@babel/template": {
@@ -677,9 +671,9 @@
                     }
                 },
                 "@babel/traverse": {
-                    "version": "7.18.2",
-                    "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.18.2.tgz",
-                    "integrity": "sha512-9eNwoeovJ6KH9zcCNnENY7DMFwTU9JdGCFtqNLfUAqtUHRCOsTOqWoffosP8vKmNYeSBUv3yVJXjfd8ucwOjUA==",
+                    "version": "7.18.5",
+                    "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.18.5.tgz",
+                    "integrity": "sha512-aKXj1KT66sBj0vVzk6rEeAO6Z9aiiQ68wfDgge3nHhA/my6xMM/7HGQUNumKZaoa2qUPQ5whJG9aAifsxUKfLA==",
                     "dev": true,
                     "requires": {
                         "@babel/code-frame": "^7.16.7",
@@ -688,8 +682,8 @@
                         "@babel/helper-function-name": "^7.17.9",
                         "@babel/helper-hoist-variables": "^7.16.7",
                         "@babel/helper-split-export-declaration": "^7.16.7",
-                        "@babel/parser": "^7.18.0",
-                        "@babel/types": "^7.18.2",
+                        "@babel/parser": "^7.18.5",
+                        "@babel/types": "^7.18.4",
                         "debug": "^4.1.0",
                         "globals": "^11.1.0"
                     }
@@ -1227,9 +1221,9 @@
                     }
                 },
                 "@babel/parser": {
-                    "version": "7.18.4",
-                    "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.18.4.tgz",
-                    "integrity": "sha512-FDge0dFazETFcxGw/EXzOkN8uJp0PC7Qbm+Pe9T+av2zlBpOgunFHkQPPn+eRuClU73JF+98D531UgayY89tow==",
+                    "version": "7.18.5",
+                    "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.18.5.tgz",
+                    "integrity": "sha512-YZWVaglMiplo7v8f1oMQ5ZPQr0vn7HPeZXxXWsxXJRjGVrzUFn9OxFQl1sb5wzfootjA/yChhW84BV+383FSOw==",
                     "dev": true
                 },
                 "@babel/template": {
@@ -1244,9 +1238,9 @@
                     }
                 },
                 "@babel/traverse": {
-                    "version": "7.18.2",
-                    "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.18.2.tgz",
-                    "integrity": "sha512-9eNwoeovJ6KH9zcCNnENY7DMFwTU9JdGCFtqNLfUAqtUHRCOsTOqWoffosP8vKmNYeSBUv3yVJXjfd8ucwOjUA==",
+                    "version": "7.18.5",
+                    "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.18.5.tgz",
+                    "integrity": "sha512-aKXj1KT66sBj0vVzk6rEeAO6Z9aiiQ68wfDgge3nHhA/my6xMM/7HGQUNumKZaoa2qUPQ5whJG9aAifsxUKfLA==",
                     "dev": true,
                     "requires": {
                         "@babel/code-frame": "^7.16.7",
@@ -1255,8 +1249,8 @@
                         "@babel/helper-function-name": "^7.17.9",
                         "@babel/helper-hoist-variables": "^7.16.7",
                         "@babel/helper-split-export-declaration": "^7.16.7",
-                        "@babel/parser": "^7.18.0",
-                        "@babel/types": "^7.18.2",
+                        "@babel/parser": "^7.18.5",
+                        "@babel/types": "^7.18.4",
                         "debug": "^4.1.0",
                         "globals": "^11.1.0"
                     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -4893,9 +4893,9 @@
             }
         },
         "@types/eslint": {
-            "version": "8.4.2",
-            "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-8.4.2.tgz",
-            "integrity": "sha512-Z1nseZON+GEnFjJc04sv4NSALGjhFwy6K0HXt7qsn5ArfAKtb63dXNJHf+1YW6IpOIYRBGUbu3GwJdj8DGnCjA==",
+            "version": "8.4.3",
+            "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-8.4.3.tgz",
+            "integrity": "sha512-YP1S7YJRMPs+7KZKDb9G63n8YejIwW9BALq7a5j2+H4yl6iOv9CB29edho+cuFRrvmJbbaH2yiVChKLJVysDGw==",
             "dev": true,
             "requires": {
                 "@types/estree": "*",
@@ -5775,9 +5775,9 @@
             }
         },
         "acorn": {
-            "version": "8.7.0",
-            "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.7.0.tgz",
-            "integrity": "sha512-V/LGr1APy+PXIwKebEWrkZPwoeoF+w1jiOBUmuxuiUIaOHtob8Qc9BTrYo7VuI5fR8tqsy+buA2WFooR5olqvQ==",
+            "version": "8.7.1",
+            "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.7.1.tgz",
+            "integrity": "sha512-Xx54uLJQZ19lKygFXOWsscKUbsBZW0CPykPhVQdhIeIwrbPmJzqeASDInc8nKBnp/JT6igTs82qPXz069H8I/A==",
             "dev": true
         },
         "acorn-import-assertions": {
@@ -13397,15 +13397,15 @@
             }
         },
         "terser-webpack-plugin": {
-            "version": "5.3.1",
-            "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-5.3.1.tgz",
-            "integrity": "sha512-GvlZdT6wPQKbDNW/GDQzZFg/j4vKU96yl2q6mcUkzKOgW4gwf1Z8cZToUCrz31XHlPWH8MVb1r2tFtdDtTGJ7g==",
+            "version": "5.3.3",
+            "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-5.3.3.tgz",
+            "integrity": "sha512-Fx60G5HNYknNTNQnzQ1VePRuu89ZVYWfjRAeT5rITuCY/1b08s49e5kSQwHDirKZWuoKOBRFS98EUUoZ9kLEwQ==",
             "dev": true,
             "requires": {
+                "@jridgewell/trace-mapping": "^0.3.7",
                 "jest-worker": "^27.4.5",
                 "schema-utils": "^3.1.1",
                 "serialize-javascript": "^6.0.0",
-                "source-map": "^0.6.1",
                 "terser": "^5.7.2"
             },
             "dependencies": {
@@ -13419,12 +13419,6 @@
                         "ajv": "^6.12.5",
                         "ajv-keywords": "^3.5.2"
                     }
-                },
-                "source-map": {
-                    "version": "0.6.1",
-                    "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-                    "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-                    "dev": true
                 }
             }
         },
@@ -13945,9 +13939,9 @@
             }
         },
         "watchpack": {
-            "version": "2.3.1",
-            "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-2.3.1.tgz",
-            "integrity": "sha512-x0t0JuydIo8qCNctdDrn1OzH/qDzk2+rdCOC3YzumZ42fiMqmQ7T3xQurykYMhYfHaPHTp4ZxAx2NfUo1K6QaA==",
+            "version": "2.4.0",
+            "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-2.4.0.tgz",
+            "integrity": "sha512-Lcvm7MGST/4fup+ifyKi2hjyIAwcdI4HRgtvTpIUxBRhB+RFtUh8XtDOxUfctVCnhVi+QQj49i91OyvzkJl6cg==",
             "dev": true,
             "requires": {
                 "glob-to-regexp": "^0.4.1",
@@ -13979,9 +13973,9 @@
             "dev": true
         },
         "webpack": {
-            "version": "5.72.1",
-            "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.72.1.tgz",
-            "integrity": "sha512-dXG5zXCLspQR4krZVR6QgajnZOjW2K/djHvdcRaDQvsjV9z9vaW6+ja5dZOYbqBBjF6kGXka/2ZyxNdc+8Jung==",
+            "version": "5.73.0",
+            "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.73.0.tgz",
+            "integrity": "sha512-svjudQRPPa0YiOYa2lM/Gacw0r6PvxptHj4FuEKQ2kX05ZLkjbVc5MnPs6its5j7IZljnIqSVo/OsY2X0IpHGA==",
             "dev": true,
             "requires": {
                 "@types/eslint-scope": "^3.7.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -7425,9 +7425,9 @@
             "dev": true
         },
         "eslint": {
-            "version": "8.16.0",
-            "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.16.0.tgz",
-            "integrity": "sha512-MBndsoXY/PeVTDJeWsYj7kLZ5hQpJOfMYLsF6LicLHQWbRDG19lK5jOix4DPl8yY4SUFcE3txy86OzFLWT+yoA==",
+            "version": "8.18.0",
+            "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.18.0.tgz",
+            "integrity": "sha512-As1EfFMVk7Xc6/CvhssHUjsAQSkpfXvUGMFC3ce8JDe6WvqCgRrLOBQbVpsBFr1X1V+RACOadnzVvcUS5ni2bA==",
             "dev": true,
             "requires": {
                 "@eslint/eslintrc": "^1.3.0",
@@ -7692,12 +7692,6 @@
                 "eslint-visitor-keys": "^3.3.0"
             },
             "dependencies": {
-                "acorn": {
-                    "version": "8.7.1",
-                    "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.7.1.tgz",
-                    "integrity": "sha512-Xx54uLJQZ19lKygFXOWsscKUbsBZW0CPykPhVQdhIeIwrbPmJzqeASDInc8nKBnp/JT6igTs82qPXz069H8I/A==",
-                    "dev": true
-                },
                 "eslint-visitor-keys": {
                     "version": "3.3.0",
                     "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.3.0.tgz",
@@ -7919,7 +7913,7 @@
         "fast-levenshtein": {
             "version": "2.0.6",
             "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
-            "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
+            "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
             "dev": true
         },
         "fastest-levenshtein": {
@@ -9914,7 +9908,7 @@
         "json-stable-stringify-without-jsonify": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
-            "integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=",
+            "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
             "dev": true
         },
         "json5": {
@@ -10804,7 +10798,7 @@
         "natural-compare": {
             "version": "1.4.0",
             "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
-            "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
+            "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
             "dev": true
         },
         "negotiator": {
@@ -13425,7 +13419,7 @@
         "text-table": {
             "version": "0.2.0",
             "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
-            "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
+            "integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==",
             "dev": true
         },
         "through": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -5275,14 +5275,14 @@
             "dev": true
         },
         "@typescript-eslint/eslint-plugin": {
-            "version": "5.27.1",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.27.1.tgz",
-            "integrity": "sha512-6dM5NKT57ZduNnJfpY81Phe9nc9wolnMCnknb1im6brWi1RYv84nbMS3olJa27B6+irUVV1X/Wb+Am0FjJdGFw==",
+            "version": "5.28.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.28.0.tgz",
+            "integrity": "sha512-DXVU6Cg29H2M6EybqSg2A+x8DgO9TCUBRp4QEXQHJceLS7ogVDP0g3Lkg/SZCqcvkAP/RruuQqK0gdlkgmhSUA==",
             "dev": true,
             "requires": {
-                "@typescript-eslint/scope-manager": "5.27.1",
-                "@typescript-eslint/type-utils": "5.27.1",
-                "@typescript-eslint/utils": "5.27.1",
+                "@typescript-eslint/scope-manager": "5.28.0",
+                "@typescript-eslint/type-utils": "5.28.0",
+                "@typescript-eslint/utils": "5.28.0",
                 "debug": "^4.3.4",
                 "functional-red-black-tree": "^1.0.1",
                 "ignore": "^5.2.0",
@@ -5292,28 +5292,28 @@
             },
             "dependencies": {
                 "@typescript-eslint/scope-manager": {
-                    "version": "5.27.1",
-                    "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.27.1.tgz",
-                    "integrity": "sha512-fQEOSa/QroWE6fAEg+bJxtRZJTH8NTskggybogHt4H9Da8zd4cJji76gA5SBlR0MgtwF7rebxTbDKB49YUCpAg==",
+                    "version": "5.28.0",
+                    "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.28.0.tgz",
+                    "integrity": "sha512-LeBLTqF/he1Z+boRhSqnso6YrzcKMTQ8bO/YKEe+6+O/JGof9M0g3IJlIsqfrK/6K03MlFIlycbf1uQR1IjE+w==",
                     "dev": true,
                     "requires": {
-                        "@typescript-eslint/types": "5.27.1",
-                        "@typescript-eslint/visitor-keys": "5.27.1"
+                        "@typescript-eslint/types": "5.28.0",
+                        "@typescript-eslint/visitor-keys": "5.28.0"
                     }
                 },
                 "@typescript-eslint/types": {
-                    "version": "5.27.1",
-                    "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.27.1.tgz",
-                    "integrity": "sha512-LgogNVkBhCTZU/m8XgEYIWICD6m4dmEDbKXESCbqOXfKZxRKeqpiJXQIErv66sdopRKZPo5l32ymNqibYEH/xg==",
+                    "version": "5.28.0",
+                    "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.28.0.tgz",
+                    "integrity": "sha512-2OOm8ZTOQxqkPbf+DAo8oc16sDlVR5owgJfKheBkxBKg1vAfw2JsSofH9+16VPlN9PWtv8Wzhklkqw3k/zCVxA==",
                     "dev": true
                 },
                 "@typescript-eslint/visitor-keys": {
-                    "version": "5.27.1",
-                    "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.27.1.tgz",
-                    "integrity": "sha512-xYs6ffo01nhdJgPieyk7HAOpjhTsx7r/oB9LWEhwAXgwn33tkr+W8DI2ChboqhZlC4q3TC6geDYPoiX8ROqyOQ==",
+                    "version": "5.28.0",
+                    "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.28.0.tgz",
+                    "integrity": "sha512-BtfP1vCor8cWacovzzPFOoeW4kBQxzmhxGoOpt0v1SFvG+nJ0cWaVdJk7cky1ArTcFHHKNIxyo2LLr3oNkSuXA==",
                     "dev": true,
                     "requires": {
-                        "@typescript-eslint/types": "5.27.1",
+                        "@typescript-eslint/types": "5.28.0",
                         "eslint-visitor-keys": "^3.3.0"
                     }
                 },
@@ -5366,12 +5366,12 @@
             }
         },
         "@typescript-eslint/type-utils": {
-            "version": "5.27.1",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.27.1.tgz",
-            "integrity": "sha512-+UC1vVUWaDHRnC2cQrCJ4QtVjpjjCgjNFpg8b03nERmkHv9JV9X5M19D7UFMd+/G7T/sgFwX2pGmWK38rqyvXw==",
+            "version": "5.28.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.28.0.tgz",
+            "integrity": "sha512-SyKjKh4CXPglueyC6ceAFytjYWMoPHMswPQae236zqe1YbhvCVQyIawesYywGiu98L9DwrxsBN69vGIVxJ4mQQ==",
             "dev": true,
             "requires": {
-                "@typescript-eslint/utils": "5.27.1",
+                "@typescript-eslint/utils": "5.28.0",
                 "debug": "^4.3.4",
                 "tsutils": "^3.21.0"
             },
@@ -5449,43 +5449,43 @@
             }
         },
         "@typescript-eslint/utils": {
-            "version": "5.27.1",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.27.1.tgz",
-            "integrity": "sha512-mZ9WEn1ZLDaVrhRaYgzbkXBkTPghPFsup8zDbbsYTxC5OmqrFE7skkKS/sraVsLP3TcT3Ki5CSyEFBRkLH/H/w==",
+            "version": "5.28.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.28.0.tgz",
+            "integrity": "sha512-E60N5L0fjv7iPJV3UGc4EC+A3Lcj4jle9zzR0gW7vXhflO7/J29kwiTGITA2RlrmPokKiZbBy2DgaclCaEUs6g==",
             "dev": true,
             "requires": {
                 "@types/json-schema": "^7.0.9",
-                "@typescript-eslint/scope-manager": "5.27.1",
-                "@typescript-eslint/types": "5.27.1",
-                "@typescript-eslint/typescript-estree": "5.27.1",
+                "@typescript-eslint/scope-manager": "5.28.0",
+                "@typescript-eslint/types": "5.28.0",
+                "@typescript-eslint/typescript-estree": "5.28.0",
                 "eslint-scope": "^5.1.1",
                 "eslint-utils": "^3.0.0"
             },
             "dependencies": {
                 "@typescript-eslint/scope-manager": {
-                    "version": "5.27.1",
-                    "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.27.1.tgz",
-                    "integrity": "sha512-fQEOSa/QroWE6fAEg+bJxtRZJTH8NTskggybogHt4H9Da8zd4cJji76gA5SBlR0MgtwF7rebxTbDKB49YUCpAg==",
+                    "version": "5.28.0",
+                    "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.28.0.tgz",
+                    "integrity": "sha512-LeBLTqF/he1Z+boRhSqnso6YrzcKMTQ8bO/YKEe+6+O/JGof9M0g3IJlIsqfrK/6K03MlFIlycbf1uQR1IjE+w==",
                     "dev": true,
                     "requires": {
-                        "@typescript-eslint/types": "5.27.1",
-                        "@typescript-eslint/visitor-keys": "5.27.1"
+                        "@typescript-eslint/types": "5.28.0",
+                        "@typescript-eslint/visitor-keys": "5.28.0"
                     }
                 },
                 "@typescript-eslint/types": {
-                    "version": "5.27.1",
-                    "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.27.1.tgz",
-                    "integrity": "sha512-LgogNVkBhCTZU/m8XgEYIWICD6m4dmEDbKXESCbqOXfKZxRKeqpiJXQIErv66sdopRKZPo5l32ymNqibYEH/xg==",
+                    "version": "5.28.0",
+                    "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.28.0.tgz",
+                    "integrity": "sha512-2OOm8ZTOQxqkPbf+DAo8oc16sDlVR5owgJfKheBkxBKg1vAfw2JsSofH9+16VPlN9PWtv8Wzhklkqw3k/zCVxA==",
                     "dev": true
                 },
                 "@typescript-eslint/typescript-estree": {
-                    "version": "5.27.1",
-                    "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.27.1.tgz",
-                    "integrity": "sha512-DnZvvq3TAJ5ke+hk0LklvxwYsnXpRdqUY5gaVS0D4raKtbznPz71UJGnPTHEFo0GDxqLOLdMkkmVZjSpET1hFw==",
+                    "version": "5.28.0",
+                    "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.28.0.tgz",
+                    "integrity": "sha512-9GX+GfpV+F4hdTtYc6OV9ZkyYilGXPmQpm6AThInpBmKJEyRSIjORJd1G9+bknb7OTFYL+Vd4FBJAO6T78OVqA==",
                     "dev": true,
                     "requires": {
-                        "@typescript-eslint/types": "5.27.1",
-                        "@typescript-eslint/visitor-keys": "5.27.1",
+                        "@typescript-eslint/types": "5.28.0",
+                        "@typescript-eslint/visitor-keys": "5.28.0",
                         "debug": "^4.3.4",
                         "globby": "^11.1.0",
                         "is-glob": "^4.0.3",
@@ -5494,12 +5494,12 @@
                     }
                 },
                 "@typescript-eslint/visitor-keys": {
-                    "version": "5.27.1",
-                    "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.27.1.tgz",
-                    "integrity": "sha512-xYs6ffo01nhdJgPieyk7HAOpjhTsx7r/oB9LWEhwAXgwn33tkr+W8DI2ChboqhZlC4q3TC6geDYPoiX8ROqyOQ==",
+                    "version": "5.28.0",
+                    "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.28.0.tgz",
+                    "integrity": "sha512-BtfP1vCor8cWacovzzPFOoeW4kBQxzmhxGoOpt0v1SFvG+nJ0cWaVdJk7cky1ArTcFHHKNIxyo2LLr3oNkSuXA==",
                     "dev": true,
                     "requires": {
-                        "@typescript-eslint/types": "5.27.1",
+                        "@typescript-eslint/types": "5.28.0",
                         "eslint-visitor-keys": "^3.3.0"
                     }
                 },

--- a/package-lock.json
+++ b/package-lock.json
@@ -9743,7 +9743,7 @@
         "isarray": {
             "version": "0.0.1",
             "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-            "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
+            "integrity": "sha512-D2S+3GLxWH+uhrNEcoh/fnmYeP8E8/zHl644d/jdA0g2uyXvy3sb0qxotE+ne0LtccHknQzWwZEzhak7oJ0COQ=="
         },
         "isexe": {
             "version": "2.0.0",
@@ -12028,9 +12028,9 @@
             }
         },
         "react-router": {
-            "version": "5.3.2",
-            "resolved": "https://registry.npmjs.org/react-router/-/react-router-5.3.2.tgz",
-            "integrity": "sha512-GlsSUckZ4JthgsW5lV9oSCs5CoQ7q0t0Ump/Y5YQ8qhiS+WjaAhaoJhc7otpZW9eVhO6N06vYPt40SpEzuuZeg==",
+            "version": "5.3.3",
+            "resolved": "https://registry.npmjs.org/react-router/-/react-router-5.3.3.tgz",
+            "integrity": "sha512-mzQGUvS3bM84TnbtMYR8ZjKnuPJ71IjSzR+DE6UkUqvN4czWIqEs17yLL8xkAycv4ev0AiN+IGrWu88vJs/p2w==",
             "requires": {
                 "@babel/runtime": "^7.12.13",
                 "history": "^4.9.0",
@@ -12045,15 +12045,15 @@
             }
         },
         "react-router-dom": {
-            "version": "5.3.2",
-            "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-5.3.2.tgz",
-            "integrity": "sha512-j8sAq4YdWsrkM2DfDX26GnjtDKWUSd65LzHyBz8NcgFcK0ct7oTvYlwhOr532xpXsYP1HONq6QqUGA7GhbAY5w==",
+            "version": "5.3.3",
+            "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-5.3.3.tgz",
+            "integrity": "sha512-Ov0tGPMBgqmbu5CDmN++tv2HQ9HlWDuWIIqn4b88gjlAN5IHI+4ZUZRcpz9Hl0azFIwihbLDYw1OiHGRo7ZIng==",
             "requires": {
                 "@babel/runtime": "^7.12.13",
                 "history": "^4.9.0",
                 "loose-envify": "^1.3.1",
                 "prop-types": "^15.6.2",
-                "react-router": "5.3.2",
+                "react-router": "5.3.3",
                 "tiny-invariant": "^1.0.2",
                 "tiny-warning": "^1.0.0"
             }

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
         "@ls-lint/ls-lint": "^1.11.0",
         "@redhat-cloud-services/frontend-components-config": "^4.6.13",
         "@redhat-cloud-services/frontend-components-config-utilities": "^1.5.20",
-        "@typescript-eslint/eslint-plugin": "^5.27.1",
+        "@typescript-eslint/eslint-plugin": "^5.28.0",
         "@typescript-eslint/parser": "^5.22.0",
         "babel-core": "^7.0.0-bridge.0",
         "babel-plugin-lodash": "^3.3.4",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
         "react-dom": "^16.14.0",
         "react-markdown": "^8.0.3",
         "react-redux": "^8.0.2",
-        "react-router-dom": "^5.3.2",
+        "react-router-dom": "^5.3.3",
         "react-router-hash-link": "^2.4.3",
         "redux": "^4.2.0",
         "redux-logger": "^3.0.6",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
         "redux-promise-middleware": "^6.1.2"
     },
     "devDependencies": {
-        "@babel/core": "^7.18.2",
+        "@babel/core": "^7.18.5",
         "@babel/plugin-syntax-dynamic-import": "^7.8.3",
         "@babel/plugin-transform-runtime": "^7.18.2",
         "@babel/preset-env": "^7.16.11",

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
         "stylelint-config-standard-scss": "^4.0.0",
         "stylelint-scss": "^4.2.0",
         "typescript": "^4.6.3",
-        "webpack": "^5.72.1",
+        "webpack": "^5.73.0",
         "webpack-cli": "^4.9.2"
     },
     "scripts": {

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
         "babel-plugin-lodash": "^3.3.4",
         "babel-plugin-macros": "^3.1.0",
         "css-loader": "^6.5.1",
-        "eslint": "^8.16.0",
+        "eslint": "^8.18.0",
         "eslint-config-prettier": "^8.5.0",
         "eslint-plugin-react": "^7.29.3",
         "fork-ts-checker-webpack-plugin": "^7.2.11",

--- a/pr_check.sh
+++ b/pr_check.sh
@@ -1,0 +1,96 @@
+#!/bin/bash
+
+# --------------------------------------------
+# Export vars for helper scripts to use
+# --------------------------------------------
+# name of app-sre "application" folder this component lives in; needs to match for quay
+export COMPONENT="automation-hub"
+export WORKSPACE=${WORKSPACE:-$APP_ROOT} # if running in jenkins, use the build's workspace
+export APP_ROOT=$(pwd)
+COMMON_BUILDER=https://raw.githubusercontent.com/RedHatInsights/insights-frontend-builder-common/master
+export NODE_BUILD_VERSION=14
+
+export APP_NAME="automation-hub"  # name of app-sre "application" folder this component lives in
+export COMPONENT_NAME="automation-hub"  # name of app-sre "resourceTemplate" in deploy.yaml for this component
+export COMPONENTS_W_RESOURCES="all"  # components which should preserve resource settings (optional, default: none)
+
+export IMAGE_FRONTEND="quay.io/cloudservices/ansible-hub-ui"
+export IMAGE_FRONTEND_TAG=$(git rev-parse --short=7 HEAD)
+export IMAGE_FRONTEND_SHA1=$(git rev-parse HEAD)
+export IMAGE=${IMAGE_FRONTEND}
+
+export IMAGE_BACKEND="quay.io/cloudservices/automation-hub-galaxy-ng"
+export IMAGE_BACKEND_TAG=$(curl -s https://api.github.com/repos/ansible/galaxy_ng/commits/master | jq -r '.sha' | head -c7)
+export BACKUP_APP_ROOT=$APP_ROOT
+
+set -exv
+# source is preferred to | bash -s in this case to avoid a subshell
+source <(curl -sSL $COMMON_BUILDER/src/frontend-build.sh)
+BUILD_RESULTS=$?
+
+# install bonfire repo/initialize
+CICD_URL=https://raw.githubusercontent.com/RedHatInsights/bonfire/master/cicd
+curl -s "$CICD_URL/bootstrap.sh" > .cicd_bootstrap.sh
+source .cicd_bootstrap.sh
+source ${CICD_ROOT}/_common_deploy_logic.sh
+
+# deploy to ephemeral
+export NAMESPACE=$(bonfire namespace reserve)
+bonfire deploy \
+    ${APP_NAME} \
+    --source=appsre \
+    --ref-env insights-stage \
+    --set-template-ref ${COMPONENT_NAME}=master \
+    --set-image-tag ${IMAGE_BACKEND}=${IMAGE_BACKEND_TAG} \
+    --set-template-ref automation-hub-frontend=${IMAGE_FRONTEND_SHA1} \
+    --frontends=true \
+    --namespace ${NAMESPACE} \
+    --timeout ${DEPLOY_TIMEOUT} \
+    ${COMPONENTS_ARG} \
+    ${COMPONENTS_RESOURCES_ARG} \
+    --set-parameter ${COMPONENT_NAME}/IMPORTER_JOB_NAMESPACE=${NAMESPACE}
+
+# configure ephemeral environment
+git clone https://github.com/ansible/galaxy_ng.git
+cd galaxy_ng
+oc project ${NAMESPACE}
+
+echo "patching CONTENT_ORIGIN"
+CONTENT_ORIGIN=$(oc get route -l frontend=automation-hub -o jsonpath='https://{.items[0].spec.host}')
+oc patch clowdapp automation-hub --type=json -p '[{"op": "replace", "path": "/spec/deployments/1/podSpec/env/1/value", "value": "'"${CONTENT_ORIGIN}"'"}]'
+sleep 5
+oc rollout status deploy/automation-hub-galaxy-api
+
+echo "patching PULP_AWS_S3_ENDPOINT_URL"
+oc create route edge minio --service=env-${NAMESPACE}-minio --insecure-policy=Redirect
+MINIO_ROUTE=$(oc get route minio -o jsonpath='https://{.spec.host}{"\n"}')
+oc patch clowdapp automation-hub --type=json -p '[{"op": "add", "path": "/spec/deployments/2/podSpec/env/-", "value": {"name": "PULP_AWS_S3_ENDPOINT_URL", "value": "'"${MINIO_ROUTE}"'"}}]'
+sleep 5
+oc rollout status deploy/automation-hub-pulp-content-app
+
+echo "Get pod names"
+AH_API_POD=$(oc get pod -l pod=automation-hub-galaxy-api -o jsonpath='{.items[0].metadata.name}')
+DB_POD=$(oc get pod -l service=db -o jsonpath='{.items[0].metadata.name}')
+
+echo "Creating test data"
+oc exec $AH_API_POD -c automation-hub-galaxy-api -i -- /entrypoint.sh manage shell < dev/ephemeral/create_objects.py
+
+echo "Fixing keycloak user permissions"
+oc exec $AH_API_POD -c automation-hub-galaxy-api -i -- /entrypoint.sh manage shell < dev/ephemeral/fixuser.py
+
+cd ..
+# end configuring ephemeral
+
+# smoke tests
+#source dev/ephemeral/smoke_test.sh
+
+# Stubbed out for now, will be added as tests are enabled
+mkdir -p $WORKSPACE/artifacts
+cat << EOF > $WORKSPACE/artifacts/junit-dummy.xml
+<testsuite tests="1">
+    <testcase classname="dummy" name="dummytest"/>
+</testsuite>
+EOF
+
+# teardown_docker
+exit $BUILD_RESULTS

--- a/src/api/response-types/collection.ts
+++ b/src/api/response-types/collection.ts
@@ -1,3 +1,5 @@
+type SignState = 'signed' | 'unsigned' | 'partial';
+
 export class CollectionUploadType {
   id: string;
   file: File;
@@ -18,7 +20,7 @@ export class CollectionVersion {
   namespace: string;
   name: string;
   repository_list: string[];
-  sign_state: 'signed' | 'unsigned' | 'partial';
+  sign_state: SignState;
 }
 
 class RenderedFile {
@@ -45,7 +47,7 @@ export class CollectionVersionDetail extends CollectionVersion {
       pulp_created: string;
     }[];
   };
-  sign_state: 'signed' | 'unsigned' | 'partial';
+  sign_state: SignState;
   requires_ansible?: string;
   docs_blob: DocsBlobType;
 }
@@ -57,7 +59,7 @@ export class CollectionListType {
   // download_count: number;
   deprecated: boolean;
   latest_version: CollectionVersion;
-  sign_state: 'unsigned' | 'signed' | 'partial';
+  sign_state: SignState;
 
   namespace: {
     id: number;
@@ -115,14 +117,14 @@ export class CollectionDetailType {
     id: string;
     version: string;
     created: string;
-    sign_state: 'unsigned' | 'signed' | 'partial';
+    sign_state: SignState;
   }[];
   latest_version: CollectionVersionDetail;
 
   id: string;
   name: string;
   description: string;
-  sign_state: 'unsigned' | 'signed' | 'partial';
+  sign_state: SignState;
   total_versions: number;
   signed_versions: number;
   unsigned_versions: number;

--- a/src/api/response-types/feature-flags.ts
+++ b/src/api/response-types/feature-flags.ts
@@ -1,5 +1,13 @@
 export class FeatureFlagsType {
+  execution_environments: boolean;
+  external_authentication: boolean;
+
+  // signing
+  can_create_signatures: boolean;
+  can_upload_signatures: boolean;
   collection_auto_sign: boolean;
   collection_signing: boolean;
-  execution_environments: boolean;
+  display_signatures: boolean;
+  require_upload_signatures: boolean;
+  signatures_enabled: boolean;
 }

--- a/src/components/collection-detail/download-signature-grid-item.tsx
+++ b/src/components/collection-detail/download-signature-grid-item.tsx
@@ -18,12 +18,11 @@ interface Props {
 }
 
 export const DownloadSignatureGridItem: FC<Props> = ({ version }) => {
-  const signingEnabled =
-    useContext()?.featureFlags?.collection_signing === true;
+  const { display_signatures } = useContext()?.featureFlags || {};
   const [show, setShow] = useState(false);
 
   // No signature object or the signatures is empty
-  if (!signingEnabled || version.metadata.signatures?.length < 1) {
+  if (!display_signatures || version.metadata.signatures?.length < 1) {
     return null;
   }
 

--- a/src/components/collection-list/collection-filter.tsx
+++ b/src/components/collection-list/collection-filter.tsx
@@ -47,6 +47,8 @@ export class CollectionFilter extends React.Component<IProps, IState> {
 
   render() {
     const { ignoredParams, params, updateParams } = this.props;
+    const { display_signatures } = this.context?.featureFlags || {};
+
     const filterConfig = [
       {
         id: 'keywords',
@@ -61,7 +63,7 @@ export class CollectionFilter extends React.Component<IProps, IState> {
           title: tag,
         })),
       },
-      this.context?.featureFlags?.collection_signing === true && {
+      display_signatures && {
         id: 'sign_state',
         title: t`Sign state`,
         inputType: 'select' as const,

--- a/src/components/headers/collection-header.tsx
+++ b/src/components/headers/collection-header.tsx
@@ -177,8 +177,10 @@ export class CollectionHeader extends React.Component<IProps, IState> {
 
     const latestVersion = collection.latest_version.created_at;
 
+    const { display_signatures } = this.context?.featureFlags || {};
+
     const signedString = (v) => {
-      if ('sign_state' in v) {
+      if (display_signatures && 'sign_state' in v) {
         return v.sign_state === 'signed' ? t`(signed)` : t`(unsigned)`;
       } else {
         return '';

--- a/src/components/headers/collection-header.tsx
+++ b/src/components/headers/collection-header.tsx
@@ -37,6 +37,7 @@ import {
   DeleteModal,
   SignSingleCertificateModal,
   SignAllCertificatesModal,
+  UploadSingCertificateModal,
   ImportModal,
 } from 'src/components';
 
@@ -46,6 +47,9 @@ import {
   SignCollectionAPI,
   CollectionListType,
   MyNamespaceAPI,
+  CollectionVersion,
+  Repositories,
+  CertificateUploadAPI,
 } from 'src/api';
 import { Paths, formatPath } from 'src/paths';
 import {
@@ -93,6 +97,8 @@ interface IState {
   isDeletionPending: boolean;
   updateCollection: CollectionListType;
   showImportModal: boolean;
+  uploadCertificateModalOpen: boolean;
+  versionToUploadCertificate: CollectionVersion;
 }
 
 export class CollectionHeader extends React.Component<IProps, IState> {
@@ -120,6 +126,8 @@ export class CollectionHeader extends React.Component<IProps, IState> {
       isDeletionPending: false,
       updateCollection: null,
       showImportModal: false,
+      uploadCertificateModalOpen: false,
+      versionToUploadCertificate: undefined,
     };
   }
 
@@ -177,7 +185,8 @@ export class CollectionHeader extends React.Component<IProps, IState> {
 
     const latestVersion = collection.latest_version.created_at;
 
-    const { display_signatures } = this.context?.featureFlags || {};
+    const { display_signatures, can_upload_signatures } =
+      this.context?.featureFlags || {};
 
     const signedString = (v) => {
       if (display_signatures && 'sign_state' in v) {
@@ -239,7 +248,7 @@ export class CollectionHeader extends React.Component<IProps, IState> {
           {t`Delete version ${collection.latest_version.version}`}
         </DropdownItem>
       ),
-      canSign && (
+      canSign && !can_upload_signatures && (
         <DropdownItem
           key='sign-all'
           onClick={() => this.setState({ isOpenSignAllModal: true })}
@@ -250,7 +259,16 @@ export class CollectionHeader extends React.Component<IProps, IState> {
       canSign && (
         <DropdownItem
           key='sign-version'
-          onClick={() => this.setState({ isOpenSignModal: true })}
+          onClick={() => {
+            if (can_upload_signatures) {
+              this.setState({
+                uploadCertificateModalOpen: true,
+                versionToUploadCertificate: collection.latest_version,
+              });
+            } else {
+              this.setState({ isOpenSignModal: true });
+            }
+          }}
         >
           {t`Sign version ${collection.latest_version.version}`}
         </DropdownItem>
@@ -291,6 +309,11 @@ export class CollectionHeader extends React.Component<IProps, IState> {
         )}
         {canSign && (
           <>
+            <UploadSingCertificateModal
+              isOpen={this.state.uploadCertificateModalOpen}
+              onCancel={() => this.closeUploadCertificateModal()}
+              onSubmit={(d) => this.submitCertificate(d)}
+            />
             <SignAllCertificatesModal
               name={collectionName}
               numberOfAffected={collection.total_versions}
@@ -637,6 +660,69 @@ export class CollectionHeader extends React.Component<IProps, IState> {
 
   private renderSelectVersions(versions, count) {
     return versions.slice(0, count);
+  }
+
+  private async submitCertificate(file: File) {
+    const version = this.state.versionToUploadCertificate;
+    const response = await Repositories.getRepository({
+      name: this.context.selectedRepo,
+    });
+    const signed_collection = `${PULP_API_BASE_PATH}content/ansible/collection_versions/${version.id}/`;
+    console.log(
+      'signature upload started for',
+      version,
+      response.data.results[0].pulp_href,
+      signed_collection,
+    );
+
+    this.setState({
+      alerts: this.state.alerts.concat({
+        id: 'upload-certificate',
+        variant: 'info',
+        title: t`The certificate for "${version.namespace} ${version.name} v${version.version}" is being uploaded.`,
+      }),
+    });
+
+    this.closeUploadCertificateModal();
+
+    CertificateUploadAPI.upload({
+      file,
+      repository: response.data.results[0].pulp_href,
+      signed_collection,
+    })
+      .then((result) => {
+        return waitForTask(parsePulpIDFromURL(result.data.task)).then(() => {
+          if (this.props.reload) {
+            this.props.reload();
+          }
+          this.setState({
+            alerts: this.state.alerts
+              .filter(({ id }) => id !== 'upload-certificate')
+              .concat({
+                variant: 'success',
+                title: t`Certificate for collection "${version.namespace} ${version.name} v${version.version}" has been successfully uploaded.`,
+              }),
+          });
+        });
+      })
+      .catch((error) => {
+        this.setState({
+          alerts: this.state.alerts
+            .filter(({ id }) => id !== 'upload-certificate')
+            .concat({
+              variant: 'danger',
+              title: t`The certificate for "${version.namespace} ${version.name} v${version.version}" could not be saved.`,
+              description: error,
+            }),
+        });
+      });
+  }
+
+  private closeUploadCertificateModal() {
+    this.setState({
+      uploadCertificateModalOpen: false,
+      versionToUploadCertificate: undefined,
+    });
   }
 
   private paginateVersions(versions) {

--- a/src/components/my-imports/import-list.tsx
+++ b/src/components/my-imports/import-list.tsx
@@ -6,10 +6,13 @@ import {
   Pagination,
   FormSelect,
   FormSelectOption,
-  Spinner,
   Toolbar,
 } from '@patternfly/react-core';
-import { AppliedFilters, CompoundFilter } from 'src/components';
+import {
+  AppliedFilters,
+  CompoundFilter,
+  LoadingPageSpinner,
+} from 'src/components';
 import { PulpStatus, NamespaceType, ImportListType } from 'src/api';
 import { ParamHelper } from 'src/utilities/param-helper';
 import { filterIsSet } from 'src/utilities';
@@ -141,7 +144,7 @@ export class ImportList extends React.Component<IProps, IState> {
     if (loading) {
       return (
         <div className='loading'>
-          <Spinner />
+          <LoadingPageSpinner />
         </div>
       );
     }

--- a/src/components/repositories/remote-form.tsx
+++ b/src/components/repositories/remote-form.tsx
@@ -158,6 +158,7 @@ export class RemoteForm extends React.Component<IProps, IState> {
   private renderForm(requiredFields, disabledFields) {
     const { remote, errorMessages } = this.props;
     const { filenames } = this.state;
+    const { signatures_enabled } = this.context?.featureFlags || {};
 
     const docsAnsibleLink = (
       <a
@@ -230,8 +231,7 @@ export class RemoteForm extends React.Component<IProps, IState> {
           />
         </FormGroup>
 
-        {!disabledFields.includes('signed_only') &&
-        this.context.featureFlags?.collection_signing ? (
+        {!disabledFields.includes('signed_only') && signatures_enabled ? (
           <FormGroup
             fieldId={'signed_only'}
             name={t`Signed only`}

--- a/src/components/signing/signature-badge.tsx
+++ b/src/components/signing/signature-badge.tsx
@@ -16,10 +16,9 @@ export const SignatureBadge: FC<Props> = ({
   isCompact = false,
   ...props
 }) => {
-  const signingEnabled =
-    useContext()?.featureFlags?.collection_signing === true;
+  const { display_signatures } = useContext()?.featureFlags || {};
 
-  if (!signingEnabled) {
+  if (!display_signatures) {
     return null;
   }
 

--- a/src/containers/execution-environment-list/execution_environment_list.tsx
+++ b/src/containers/execution-environment-list/execution_environment_list.tsx
@@ -354,7 +354,7 @@ class ExecutionEnvironmentList extends React.Component<
           {t`Edit`}
         </DropdownItem>
       ),
-      item.pulp.repository.remote && (
+      item.pulp.repository.remote && canEdit && (
         <DropdownItem key='sync' onClick={() => this.sync(item.name)}>
           {t`Sync from registry`}
         </DropdownItem>

--- a/src/containers/execution-environment-list/execution_environment_list.tsx
+++ b/src/containers/execution-environment-list/execution_environment_list.tsx
@@ -142,18 +142,22 @@ class ExecutionEnvironmentList extends React.Component<
         <Trans>Push container images</Trans> <ExternalLinkAltIcon />
       </Button>
     );
-    const addRemoteButton = (
-      <Button
-        onClick={() =>
-          this.setState({
-            showRemoteModal: true,
-            itemToEdit: {} as ExecutionEnvironmentType,
-          })
-        }
-        variant='primary'
-      >
-        <Trans>Add execution environment</Trans>
-      </Button>
+    const addRemoteButton = this.context.user?.model_permissions
+      ?.add_containernamespace && (
+      <>
+        <Button
+          onClick={() =>
+            this.setState({
+              showRemoteModal: true,
+              itemToEdit: {} as ExecutionEnvironmentType,
+            })
+          }
+          variant='primary'
+        >
+          <Trans>Add execution environment</Trans>
+        </Button>
+        <div>&nbsp;</div>
+      </>
     );
 
     return (
@@ -197,7 +201,6 @@ class ExecutionEnvironmentList extends React.Component<
             button={
               <>
                 {addRemoteButton}
-                <div>&nbsp;</div>
                 {pushImagesButton}
               </>
             }

--- a/src/containers/execution-environment/registry-list.tsx
+++ b/src/containers/execution-environment/registry-list.tsx
@@ -367,13 +367,15 @@ class ExecutionEnvironmentRegistryList extends React.Component<
 
   private renderTableRow(item, index: number) {
     const buttons = [
-      <Button
-        key='sync'
-        variant='secondary'
-        onClick={() => this.syncRegistry(item)}
-      >
-        <Trans>Sync from registry</Trans>
-      </Button>,
+      this.context.user.model_permissions.change_containerregistry && (
+        <Button
+          key='sync'
+          variant='secondary'
+          onClick={() => this.syncRegistry(item)}
+        >
+          <Trans>Sync from registry</Trans>
+        </Button>
+      ),
     ];
 
     const dropdownItems = [

--- a/src/containers/namespace-detail/namespace-detail.tsx
+++ b/src/containers/namespace-detail/namespace-detail.tsx
@@ -581,6 +581,7 @@ export class NamespaceDetail extends React.Component<IProps, IState> {
 
   private renderPageControls() {
     const { canSign, collections } = this.state;
+    const { can_upload_signatures } = this.context?.featureFlags || {};
 
     const dropdownItems = [
       <DropdownItem
@@ -636,7 +637,7 @@ export class NamespaceDetail extends React.Component<IProps, IState> {
           </Link>
         }
       />,
-      canSign && (
+      canSign && !can_upload_signatures && (
         <DropdownItem
           key='sign-collections'
           onClick={() => this.setState({ isOpenSignModal: true })}

--- a/src/utilities/can-sign.tsx
+++ b/src/utilities/can-sign.tsx
@@ -1,7 +1,8 @@
 export const canSign = ({ featureFlags }, namespace) => {
+  const { can_create_signatures } = featureFlags || {};
   const permissions = namespace?.related_fields?.my_permissions || [];
   return (
-    featureFlags?.collection_signing &&
+    can_create_signatures &&
     permissions.includes('galaxy.change_namespace') &&
     permissions.includes('galaxy.upload_to_namespace')
   );

--- a/src/utilities/wait-for-task.ts
+++ b/src/utilities/wait-for-task.ts
@@ -3,6 +3,9 @@ import { TaskAPI } from 'src/api';
 
 export function waitForTask(task, bailAfter = 10) {
   return TaskAPI.get(task).then((result) => {
+    if (result.data.state !== 'completed' && result.data.state !== 'running') {
+      return Promise.reject(result.data.error.description);
+    }
     if (result.data.state !== 'completed') {
       if (!bailAfter) {
         return Promise.reject(

--- a/test/cypress/integration/remote_repo_edit.js
+++ b/test/cypress/integration/remote_repo_edit.js
@@ -1,0 +1,150 @@
+describe('edit a remote repository', () => {
+  let remoteRepoUrl = '/ui/repositories?tab=remote';
+
+  beforeEach(() => {
+    cy.login();
+  });
+
+  it(`edits remote repo 'community'`, () => {
+    cy.visit(remoteRepoUrl);
+    cy.get('[aria-label="Actions"]:first').click(); // click the kebab menu on the 'community' repo
+    cy.contains('Edit').click();
+    cy.get('input[id="name"]').should('be.disabled'); //has a readonly name field
+    cy.get('input[id="url"]').clear();
+    cy.get('button').contains('Save').should('be.disabled'); // Save button disabled when required fields are missing
+    cy.get('[id="url-helper"]').should(
+      'have.text',
+      `The URL needs to be in 'http(s)://' format.`,
+    );
+
+    cy.contains('Show advanced options').click();
+
+    // enter new values
+    cy.get('input[id="url"]').type('https://galaxy.ansible.com/api/');
+    cy.get('input[id="username"]').type('test');
+    cy.get('input[id="password"]').type('test');
+    cy.get('input[id="proxy_url"]').type('https://example.org');
+    cy.get('input[id="proxy_username"]').type('test');
+    cy.get('input[id="proxy_password"]').type('test');
+    cy.fixture('/yaml/test.yaml')
+      .then(Cypress.Blob.binaryStringToBlob)
+      .then((fileContent) => {
+        cy.get('input[type="file"]').attachFile({
+          fileContent,
+          fileName: 'test.yaml',
+        });
+      });
+    cy.intercept(
+      'PUT',
+      Cypress.env('prefix') + 'content/community/v3/sync/config/',
+    ).as('editCommunityRemote');
+    cy.contains('Save').click();
+    cy.wait('@editCommunityRemote');
+
+    // verify values have been saved properly.
+    cy.get('[aria-label="Actions"]:first').click(); // click the kebab menu on the 'community' repo
+    cy.contains('Edit').click();
+
+    cy.contains('Show advanced options').click();
+    cy.get('input[id="username"]').should('have.value', 'test');
+    cy.get('input[id="proxy_url"]').should('have.value', 'https://example.org');
+    cy.get('input[id="proxy_username"]').should('have.value', 'test');
+    cy.contains('Save').click();
+    cy.wait('@editCommunityRemote');
+
+    // clear all values
+    cy.get('[aria-label="Actions"]:first').click(); // click the kebab menu on the 'community' repo
+    cy.contains('Edit').click();
+    cy.contains('Show advanced options').click();
+    cy.get('input[id="username"]').clear();
+    cy.get('input[type="password"]')
+      .siblings('button')
+      .click({ multiple: true });
+    cy.get('input[id="proxy_url"]').clear();
+    cy.get('input[id="proxy_username"]').clear();
+    cy.contains('Save').click();
+    cy.wait('@editCommunityRemote');
+
+    //check for clear values
+    cy.get('[aria-label="Actions"]:first').click(); // click the kebab menu on the 'community' repo
+    cy.contains('Edit').click();
+    cy.contains('Show advanced options').click();
+    cy.get('input[id="username"]').should('be.empty');
+    cy.get('input[id="password"]').should('be.empty');
+    cy.get('input[id="proxy_url"]').should('be.empty');
+    cy.get('input[id="proxy_username"]').should('be.empty');
+    cy.contains('Save').click();
+    cy.wait('@editCommunityRemote');
+  });
+
+  it(`edits remote repo 'rh-certified'`, () => {
+    cy.visit(remoteRepoUrl);
+    cy.get('[data-cy="kebab-toggle"]').should('be.visible');
+    cy.get('[data-cy="kebab-toggle"]').eq(1).click(); // click the kebab menu on the 'rh-certified' repo
+    cy.contains('Edit').click();
+    cy.get('input[id="name"]').should('be.disabled'); //has a readonly name field
+    cy.get('input[id="url"]').clear();
+    cy.get('button').contains('Save').should('be.disabled'); // Save button disabled when required fields are missing
+    cy.get('[id="url-helper"]').should(
+      'have.text',
+      `The URL needs to be in 'http(s)://' format.`,
+    );
+    cy.contains('Show advanced options').click();
+    // enter new values
+    cy.get('input[id="url"]').type(
+      'https://cloud.redhat.com/api/automation-hub/',
+    );
+    cy.get('input[id="username"]').type('test');
+    cy.get('input[id="password"]').type('test');
+
+    cy.get('input[id="proxy_url"]').type('https://example.org');
+    cy.get('input[id="proxy_username"]').type('test');
+    cy.get('input[id="proxy_password"]').type('test');
+    cy.intercept(
+      'PUT',
+      Cypress.env('prefix') + 'content/rh-certified/v3/sync/config/',
+    ).as('editRemote');
+    cy.contains('Save').click();
+    cy.wait('@editRemote');
+
+    // verify values have been saved properly.
+    cy.get('[aria-label="Actions"]').should('be.visible');
+    cy.get('[aria-label="Actions"]').eq(1).click(); // click the kebab menu on the 'rh-certified' repo
+    cy.contains('Edit').click();
+    cy.contains('Show advanced options').click();
+    cy.get('input[id="username"]').should('have.value', 'test');
+    cy.get('input[id="proxy_url"]').should('have.value', 'https://example.org');
+    cy.get('input[id="proxy_username"]').should('have.value', 'test');
+    cy.intercept(
+      'PUT',
+      Cypress.env('prefix') + 'content/community/v3/sync/config/',
+    ).as('editRemote');
+    cy.contains('Save').click();
+    cy.wait('@editRemote');
+
+    // clear all values
+    cy.get('[aria-label="Actions"]').should('be.visible');
+    cy.get('[aria-label="Actions"]').eq(1).click(); // click the kebab menu on the 'rh-certified' repo
+    cy.contains('Edit').click();
+    cy.contains('Show advanced options').click();
+    cy.get('input[id="username"]').clear();
+    cy.get('input[type="password"]')
+      .siblings('button')
+      .click({ multiple: true });
+    cy.get('input[id="proxy_url"]').clear();
+    cy.get('input[id="proxy_username"]').clear();
+    cy.contains('Save').click();
+    cy.wait('@editRemote');
+
+    //check for clear values
+    cy.get('[aria-label="Actions"]').eq(1).click(); // click the kebab menu on the 'rh-certified' repo
+    cy.contains('Edit').click();
+    cy.contains('Show advanced options').click();
+    cy.get('input[id="username"]').should('be.empty');
+    cy.get('input[id="password"]').should('be.empty');
+    cy.get('input[id="proxy_url"]').should('be.empty');
+    cy.get('input[id="proxy_username"]').should('be.empty');
+    cy.contains('Save').click();
+    cy.wait('@editRemote');
+  });
+});


### PR DESCRIPTION
https://issues.redhat.com/browse/AAH-1369 - update

When the flag `can_upload_signatures` is set it takes precedence over the backend signing. Therefore we are hiding the `Sign all` buttons on the collection and namespace detail pages, and changing the `Sign version x.x` to bring up the certificate upload modal. 

In addition it fixes the `waitForTask` function to return error if the task is not `running` and not `completed` so we can report failures.

**After with the `can_upload_signatures = true`**:
![Screenshot from 2022-06-20 13-06-02](https://user-images.githubusercontent.com/8531681/174588976-44754a7b-947b-4df8-a9c5-af3351a110ac.png)
![Screenshot from 2022-06-20 13-06-42](https://user-images.githubusercontent.com/8531681/174588979-35235fd7-d5c0-48ab-bfd8-93ec72f7dfb7.png)
![Screenshot from 2022-06-20 13-07-09](https://user-images.githubusercontent.com/8531681/174588982-f1d8af35-0fa2-4240-8466-fe7c5d4cef68.png)
![Screenshot from 2022-06-20 13-07-15](https://user-images.githubusercontent.com/8531681/174588986-37885d6f-6ba7-401f-b9b0-ccddee7cd7f9.png)
![Screenshot from 2022-06-20 13-07-31](https://user-images.githubusercontent.com/8531681/174588988-23165c03-b05b-4f35-9897-c469133d681d.png)
![Screenshot from 2022-06-20 13-08-41](https://user-images.githubusercontent.com/8531681/174588990-aba9c7f4-98ac-4c98-aa57-cf5f438dc8d6.png)
